### PR TITLE
External launch inclusion, camera intrinsics datatype, and config typing fixes

### DIFF
--- a/ros_sugar/base_clients.py
+++ b/ros_sugar/base_clients.py
@@ -111,7 +111,7 @@ class ServiceClientHandler:
             updated_message = set_ros_msg_from_dict(
                 msg_class=self.config.srv_type.Request, data_dict=request_fields
             )
-            self.node.get_logger().error(f"sending request {updated_message}")
+            self.node.get_logger().debug(f"sending request {updated_message}")
         except Exception as e:
             self.node.get_logger().error(
                 f"Error creating service request from dict: {e}"

--- a/ros_sugar/base_clients.py
+++ b/ros_sugar/base_clients.py
@@ -1,7 +1,7 @@
 """ROS Service/Action Client Wrapper"""
 
 import time
-from typing import Any, Callable, Optional, Dict, Union, Tuple
+from typing import Any, Callable, Optional, Dict, Tuple
 from attrs import Factory, define, field
 
 from rclpy.action.client import ActionClient
@@ -98,12 +98,12 @@ class ServiceClientHandler:
 
     def send_request_from_dict(
         self,
-        request_fields: Dict[str, Union[str, Dict]],
+        request_fields: Dict[str, Any],
     ):
         """Send a service request using a serialized Dict request data
 
         :param request_fields: Request data [key, value]
-        :type request_fields: Dict[str, str]
+        :type request_fields: Dict[str, Any]
         :return: Service result
         :rtype: Any
         """
@@ -274,13 +274,13 @@ class ActionClientHandler:
 
     def send_request_from_dict(
         self,
-        request_fields: Dict[str, Union[str, Dict]],
+        request_fields: Dict[str, Any],
         wait_until_first_feedback: bool = False,
     ) -> Optional[bool]:
         """Send an action request using a serialized Dict request data
 
         :param request_fields: Request data [key, value]
-        :type request_fields: Dict[str, Union[str, Dict]]
+        :type request_fields: Dict[str, Any]
         """
         try:
             updated_message = set_ros_msg_from_dict(

--- a/ros_sugar/config/base_attrs.py
+++ b/ros_sugar/config/base_attrs.py
@@ -276,8 +276,19 @@ class BaseAttrs:
         if generic_type := self.__is_subscripted_generic(attribute_type):
             _types = self.__get_subscribed_generic_simple_types(attribute_type)
             if generic_type is Union:
+                # A Literal inside (e.g. Optional[Literal["a", "b"]]) cannot be
+                # isinstance checked. We match it by value instead
+                literal_values = [
+                    arg
+                    for t in _types
+                    if get_origin(t) is Literal
+                    for arg in get_args(t)
+                ]
+                others = [t for t in _types if get_origin(t) is not Literal]
                 # Check if the value type is one of the valid union types
-                if not any(isinstance(value, t) for t in _types):
+                if value not in literal_values and not any(
+                    isinstance(value, t) for t in others
+                ):
                     raise TypeError(
                         f"Trying to set with incompatible type. Attribute {key} expecting '{type(attribute_to_set)}' got '{type(value)}'"
                     )

--- a/ros_sugar/config/base_validators.py
+++ b/ros_sugar/config/base_validators.py
@@ -1,10 +1,12 @@
 from functools import partial
-from typing import Any, List, Union, Callable, Optional
+from typing import Any, List, Union, Callable, Optional, TypeVar
 
 import numpy as np
 
 
 Validator = Callable[[Any, Any, Any], None]
+
+_T = TypeVar("_T")
 
 
 def gt(value: Union[int, float]) -> Validator:
@@ -47,9 +49,12 @@ def lt(value: Union[int, float]) -> Validator:
     return partial(__lt, ref_value=value)
 
 
-def in_(values: List) -> Validator:
+def in_(values: List[_T]) -> Callable[[Any, Any, _T], None]:
     """
     Validates that value is in a given list
+
+    Typed generically so that a Literal annotation on the validated field
+    survives static type inference through ``attrs.field``.
 
     :param values: Reference list of values
     :type values: List

--- a/ros_sugar/io/__init__.py
+++ b/ros_sugar/io/__init__.py
@@ -7,7 +7,7 @@ from .topic import (
     get_all_msg_types,
     get_msg_type,
 )
-from .datatypes import LaserScanData, PointCloudData
+from .datatypes import CameraIntrinsics, LaserScanData, PointCloudData
 from .callbacks import *
 
 
@@ -17,6 +17,7 @@ __all__ = [
     "AllowedTopics",
     "get_all_msg_types",
     "get_msg_type",
+    "CameraIntrinsics",
     "LaserScanData",
     "PointCloudData",
 ]

--- a/ros_sugar/io/callbacks.py
+++ b/ros_sugar/io/callbacks.py
@@ -44,6 +44,9 @@ class GenericCallback:
 
         self.input_topic = input_topic
 
+        # check for constant input (embodied-agents)
+        self._is_fixed = hasattr(input_topic, "fixed")
+
         # Node name can be changed to a node that the callback is executed in
         # at the time of setting subscriber using set_node_name
         self.node_name: str = node_name
@@ -228,6 +231,8 @@ class GenericCallback:
 
     def clear_last_msg(self):
         """Clears the last received message on the topic"""
+        if self._is_fixed:
+            return
         self.msg = None
 
 
@@ -302,8 +307,8 @@ class ImageCallback(GenericCallback):
         :type       input_topic:  Input
         """
         super().__init__(input_topic, node_name)
-        # fixed image needs to be a path to cv2 readable image
-        if hasattr(input_topic, "fixed"):
+        # fixed image needs to be a path to cv2 readable image (from embodied-agents)
+        if self._is_fixed:
             if os.path.isfile(input_topic.fixed):
                 try:
                     _image = cv2.imread(input_topic.fixed)
@@ -325,7 +330,7 @@ class ImageCallback(GenericCallback):
         :returns:   Image as bytes
         :rtype:     bytes
         """
-        if not self.msg:
+        if self.msg is None:
             return None
 
         # return bytes if fixed image has been read
@@ -354,7 +359,7 @@ class CompressedImageCallback(ImageCallback):
         :returns:   Image as bytes
         :rtype:     bytes
         """
-        if not self.msg:
+        if self.msg is None:
             return None
 
         # return bytes if fixed image has been read
@@ -380,7 +385,7 @@ class TextCallback(GenericCallback):
         :type       input_topic:  str
         """
         super().__init__(input_topic, node_name)
-        self.msg = input_topic.fixed if hasattr(input_topic, "fixed") else None
+        self.msg = input_topic.fixed if self._is_fixed else None
         self._template: Optional[Template] = None
 
     def _get_output(self, **_) -> Optional[str]:
@@ -415,7 +420,7 @@ class AudioCallback(GenericCallback):
         :type       input_topic:  str
         """
         super().__init__(input_topic, node_name)
-        if hasattr(input_topic, "fixed"):
+        if self._is_fixed:
             if os.path.isfile(input_topic.fixed):
                 try:
                     with open(input_topic.fixed, "rb") as wavfile:
@@ -475,7 +480,7 @@ class MapMetaDataCallback(GenericCallback):
         :type       input_topic:  str
         """
         super().__init__(input_topic, node_name)
-        self.msg = input_topic.fixed if hasattr(input_topic, "fixed") else None
+        self.msg = input_topic.fixed if self._is_fixed else None
 
     def _get_output(self, **_) -> Optional[Dict]:
         """

--- a/ros_sugar/io/callbacks.py
+++ b/ros_sugar/io/callbacks.py
@@ -12,7 +12,7 @@ import numpy as np
 from geometry_msgs.msg import Pose, PoseStamped
 from jinja2.environment import Template
 from nav_msgs.msg import OccupancyGrid, Odometry, Path
-from sensor_msgs.msg import Imu, JointState, LaserScan, NavSatFix, Range
+from sensor_msgs.msg import CameraInfo, Imu, JointState, LaserScan, NavSatFix, Range
 from std_msgs.msg import Header
 from rclpy.logging import get_logger
 from rclpy.subscription import Subscription
@@ -20,8 +20,10 @@ from tf2_ros import TransformStamped
 
 from . import utils
 from .datatypes import (
+    CameraIntrinsics,
     LaserScanData,
     PointCloudData,
+    read_camera_info,
     _get_laserscan_transformed_polar_coordinates,
     _quaternion_multiply,
     _rotation_matrix_from_quaternion,
@@ -1504,3 +1506,49 @@ class PointCloudCallback(GenericCallback):
                 "point_step": self.msg.point_step,
             },
         }
+
+
+class CameraInfoCallback(GenericCallback):
+    """ROS2 CameraInfo Callback Handler to process sensor_msgs/CameraInfo data"""
+
+    def __init__(self, input_topic, node_name: Optional[str] = None) -> None:
+        """
+        Constructs a new instance.
+
+        :param input_topic: Subscription topic
+        :param node_name: Name of the node using the callback
+        """
+        super().__init__(input_topic, node_name)
+        self._intrinsics: Optional[CameraIntrinsics] = None
+        self._intrinsics_key = None
+
+    def _get_output(self, **_) -> Optional[CameraIntrinsics]:
+        """
+        Gets the camera intrinsics of the last received message.
+
+        Intrinsics rarely change, so they are parsed once and reused until the
+        camera reports different ones.
+
+        :returns: Camera intrinsics
+        :rtype: Optional[CameraIntrinsics]
+        """
+        if not self.msg:
+            return None
+
+        key = (self.msg.header.frame_id, self.msg.width, self.msg.height, tuple(self.msg.p), tuple(self.msg.k))
+        if key != self._intrinsics_key:
+            self._intrinsics = read_camera_info(self.msg)
+            self._intrinsics_key = key
+        return self._intrinsics
+
+    def _get_ui_content(self, **_) -> str:
+        """Get UI content for CameraInfo: the pinhole parameters."""
+        intrinsics = self._get_output()
+        if not intrinsics:
+            return ""
+        return (
+            f"{intrinsics.width}x{intrinsics.height} in "
+            f"'{intrinsics.frame_id or 'unknown frame'}': "
+            f"f=({intrinsics.fx:.1f}, {intrinsics.fy:.1f}) "
+            f"c=({intrinsics.cx:.1f}, {intrinsics.cy:.1f})"
+        )

--- a/ros_sugar/io/callbacks.py
+++ b/ros_sugar/io/callbacks.py
@@ -1540,7 +1540,19 @@ class CameraInfoCallback(GenericCallback):
         if not self.msg:
             return None
 
-        key = (self.msg.header.frame_id, self.msg.width, self.msg.height, tuple(self.msg.p), tuple(self.msg.k))
+        # NOTE: width, height, K and P are the full-frame calibration values and do not
+        # change when the driver applies binning or a region of interest
+        roi = getattr(self.msg, "roi", None)
+        key = (
+            self.msg.header.frame_id,
+            self.msg.width,
+            self.msg.height,
+            tuple(self.msg.p),
+            tuple(self.msg.k),
+            getattr(self.msg, "binning_x", 0),
+            getattr(self.msg, "binning_y", 0),
+            (roi.x_offset, roi.y_offset, roi.width, roi.height) if roi else None,
+        )
         if key != self._intrinsics_key:
             self._intrinsics = read_camera_info(self.msg)
             self._intrinsics_key = key

--- a/ros_sugar/io/datatypes.py
+++ b/ros_sugar/io/datatypes.py
@@ -115,14 +115,12 @@ class PointCloudData(BaseAttrs):
         """Structured dtype addressing the x/y/z fields inside a point record."""
         np_format = _POINTFIELD_NP_FORMATS.get(self.x_field_datatype, "f4")
         endianness = ">" if self.is_bigendian else "<"
-        return np.dtype(
-            {
-                "names": ["x", "y", "z"],
-                "formats": [endianness + np_format] * 3,
-                "offsets": [self.x_offset, self.y_offset, self.z_offset],
-                "itemsize": self.point_step,
-            }
-        )
+        return np.dtype({
+            "names": ["x", "y", "z"],
+            "formats": [endianness + np_format] * 3,
+            "offsets": [self.x_offset, self.y_offset, self.z_offset],
+            "itemsize": self.point_step,
+        })
 
     def _unpadded(self) -> np.ndarray:
         """The raw buffer with row padding removed, so records sit contiguously."""
@@ -231,9 +229,9 @@ class PointCloudData(BaseAttrs):
             return None
 
         records = self._unpadded()[: self.height * self.width * self.point_step]
-        kept = np.ascontiguousarray(
-            records.reshape(-1, self.point_step)[keep]
-        ).reshape(-1)
+        kept = np.ascontiguousarray(records.reshape(-1, self.point_step)[keep]).reshape(
+            -1
+        )
 
         # Write the transformed coordinates back into the surviving records
         struct = kept.view(self._point_dtype())
@@ -568,6 +566,12 @@ class CameraIntrinsics(BaseAttrs):
     for a region of interest, so they always describe the image as actually
     published rather than the sensor's full frame.
 
+    When `P` was used the intrinsics describe the **rectified** image and
+    `distortion` is empty — feed them rectified (or registered) frames. Only
+    the `K` fallback pairs with the raw image and its distortion
+    coefficients; `distortion_model` is reported in both cases as sensor
+    metadata.
+
     :param fx: Focal length in pixels along x
     :param fy: Focal length in pixels along y
     :param cx: Principal point in pixels along x
@@ -594,9 +598,11 @@ class CameraIntrinsics(BaseAttrs):
     @property
     def matrix(self) -> np.ndarray:
         """Intrinsics as a 3x3 camera matrix"""
-        return np.array(
-            [[self.fx, 0.0, self.cx], [0.0, self.fy, self.cy], [0.0, 0.0, 1.0]]
-        )
+        return np.array([
+            [self.fx, 0.0, self.cx],
+            [0.0, self.fy, self.cy],
+            [0.0, 0.0, 1.0],
+        ])
 
     @property
     def focal_length(self) -> np.ndarray:
@@ -623,21 +629,29 @@ class CameraIntrinsics(BaseAttrs):
 def read_camera_info(msg) -> CameraIntrinsics:
     """Read the pinhole parameters out of a sensor_msgs/CameraInfo message.
 
+    When the rectified projection ``P`` is set, the returned intrinsics
+    describe the **rectified** image. A consumer working on the raw stream of a
+    distorted camera needs ``K`` with the distortion coefficients instead,
+    which is only what this returns when the driver leaves ``P`` unset.
+
     :param msg: sensor_msgs/CameraInfo message
     :return: Camera intrinsics describing the published image
     :rtype: CameraIntrinsics
     """
     projection = np.asarray(msg.p, dtype=np.float64)
     intrinsics = np.asarray(msg.k, dtype=np.float64)
-    # P describes the rectified image and is what a rectified stream should be
+    # NOTE: P describes the rectified image and is what a rectified stream should be
     # deprojected with; K is the raw sensor matrix and the only option when a
-    # driver leaves P unset
+    # driver leaves P unset. K pairs with the raw image's coefficients, while a
+    # rectified image has no distortion left by construction
     if projection.size == 12 and projection[0] != 0.0:
         fx, fy = projection[0], projection[5]
         cx, cy = projection[2], projection[6]
+        distortion = np.empty(0, dtype=np.float64)
     else:
         fx, fy = intrinsics[0], intrinsics[4]
         cx, cy = intrinsics[2], intrinsics[5]
+        distortion = np.asarray(msg.d, dtype=np.float64)
 
     width, height = msg.width, msg.height
 
@@ -664,7 +678,7 @@ def read_camera_info(msg) -> CameraIntrinsics:
         width=int(width),
         height=int(height),
         distortion_model=msg.distortion_model,
-        distortion=np.asarray(msg.d, dtype=np.float64),
+        distortion=distortion,
         frame_id=msg.header.frame_id,
         timestamp=msg.header.stamp.sec + msg.header.stamp.nanosec / 1e9,
     )

--- a/ros_sugar/io/datatypes.py
+++ b/ros_sugar/io/datatypes.py
@@ -553,3 +553,118 @@ def _get_laserscan_transformed_polar_coordinates(
         ranges=sorted_ranges,
         intensities=sorted_intensities,
     )
+
+
+@define
+class CameraIntrinsics(BaseAttrs):
+    """Container for sensor_msgs/CameraInfo data.
+
+    Carries the pinhole parameters that make an image metrically meaningful,
+    which is what a consumer needs to turn a pixel into a direction in space
+    (and, with a depth value, into a point).
+
+    Values are taken from the rectified projection matrix `P` when it is set,
+    falling back to the raw intrinsics `K`, and are corrected for binning and
+    for a region of interest, so they always describe the image as actually
+    published rather than the sensor's full frame.
+
+    :param fx: Focal length in pixels along x
+    :param fy: Focal length in pixels along y
+    :param cx: Principal point in pixels along x
+    :param cy: Principal point in pixels along y
+    :param width: Width of the published image in pixels
+    :param height: Height of the published image in pixels
+    :param distortion_model: Distortion model named by the camera driver
+    :param distortion: Distortion coefficients, empty for a rectified image
+    :param frame_id: Optical frame the camera reports in
+    :param timestamp: Message timestamp in seconds
+    """
+
+    fx: float = field()
+    fy: float = field()
+    cx: float = field()
+    cy: float = field()
+    width: int = field(default=0)
+    height: int = field(default=0)
+    distortion_model: str = field(default="")
+    distortion: np.ndarray = field(default=Factory(lambda: np.empty(0)), eq=False)
+    frame_id: str = field(default="")
+    timestamp: float = field(default=0.0)
+
+    @property
+    def matrix(self) -> np.ndarray:
+        """Intrinsics as a 3x3 camera matrix"""
+        return np.array(
+            [[self.fx, 0.0, self.cx], [0.0, self.fy, self.cy], [0.0, 0.0, 1.0]]
+        )
+
+    @property
+    def focal_length(self) -> np.ndarray:
+        """Focal length as (fx, fy)"""
+        return np.array([self.fx, self.fy])
+
+    @property
+    def principal_point(self) -> np.ndarray:
+        """Principal point as (cx, cy)"""
+        return np.array([self.cx, self.cy])
+
+    def matches(self, width: int, height: int) -> bool:
+        """Whether these intrinsics describe an image of the given size.
+
+        Intrinsics that do not match the image they are used with put every
+        deprojected point in the wrong place, so consumers should check.
+
+        :param width: Image width in pixels
+        :param height: Image height in pixels
+        """
+        return (self.width, self.height) == (width, height)
+
+
+def read_camera_info(msg) -> CameraIntrinsics:
+    """Read the pinhole parameters out of a sensor_msgs/CameraInfo message.
+
+    :param msg: sensor_msgs/CameraInfo message
+    :return: Camera intrinsics describing the published image
+    :rtype: CameraIntrinsics
+    """
+    projection = np.asarray(msg.p, dtype=np.float64)
+    intrinsics = np.asarray(msg.k, dtype=np.float64)
+    # P describes the rectified image and is what a rectified stream should be
+    # deprojected with; K is the raw sensor matrix and the only option when a
+    # driver leaves P unset
+    if projection.size == 12 and projection[0] != 0.0:
+        fx, fy = projection[0], projection[5]
+        cx, cy = projection[2], projection[6]
+    else:
+        fx, fy = intrinsics[0], intrinsics[4]
+        cx, cy = intrinsics[2], intrinsics[5]
+
+    width, height = msg.width, msg.height
+
+    # A region of interest moves the principal point into the sub image, and
+    # binning scales everything down with the image
+    roi = getattr(msg, "roi", None)
+    if roi is not None and (roi.width or roi.height):
+        cx -= roi.x_offset
+        cy -= roi.y_offset
+        width = roi.width or width
+        height = roi.height or height
+
+    binning_x = getattr(msg, "binning_x", 0) or 1
+    binning_y = getattr(msg, "binning_y", 0) or 1
+    if binning_x != 1 or binning_y != 1:
+        fx, cx, width = fx / binning_x, cx / binning_x, width // binning_x
+        fy, cy, height = fy / binning_y, cy / binning_y, height // binning_y
+
+    return CameraIntrinsics(
+        fx=float(fx),
+        fy=float(fy),
+        cx=float(cx),
+        cy=float(cy),
+        width=int(width),
+        height=int(height),
+        distortion_model=msg.distortion_model,
+        distortion=np.asarray(msg.d, dtype=np.float64),
+        frame_id=msg.header.frame_id,
+        timestamp=msg.header.stamp.sec + msg.header.stamp.nanosec / 1e9,
+    )

--- a/ros_sugar/io/supported_types.py
+++ b/ros_sugar/io/supported_types.py
@@ -22,6 +22,7 @@ from automatika_ros_sugar.msg import ComponentStatus as ROSComponentStatus
 
 # SENSOR_MSGS SUPPORTED ROS TYPES
 from sensor_msgs.msg import Image as ROSImage, CompressedImage as ROSCompressedImage
+from sensor_msgs.msg import CameraInfo as ROSCameraInfo
 from sensor_msgs.msg import Imu as ROSImu
 from sensor_msgs.msg import JointState as ROSJointState
 from sensor_msgs.msg import LaserScan as ROSLaserScan
@@ -557,6 +558,25 @@ class JointState(SupportedType):
         msg = ROSJointState()
         msg.position = [float(v) for v in np.asarray(output, dtype=np.float64).ravel()]
         return msg
+
+
+class CameraInfo(SupportedType):
+    """CameraInfo, the pinhole parameters that make an image metrically meaningful"""
+
+    _ros_type = ROSCameraInfo
+    callback = callbacks.CameraInfoCallback
+
+    # NOTE: Deliberately push-default (no _ui_rate_sampled); intrinsics are
+    # effectively static, so there is nothing to throttle
+
+    @classmethod
+    def convert(cls, output: ROSCameraInfo, **_) -> ROSCameraInfo:
+        """
+        Passes a ROS CameraInfo message through.
+
+        :return: ROSCameraInfo
+        """
+        return output
 
 
 class Imu(SupportedType):

--- a/ros_sugar/launch/launcher.py
+++ b/ros_sugar/launch/launcher.py
@@ -31,6 +31,7 @@ from launch.action import Action as ROSLaunchAction
 from launch.actions import (
     ExecuteProcess,
     GroupAction,
+    IncludeLaunchDescription,
     OpaqueCoroutine,
     OpaqueFunction,
     RegisterEventHandler,
@@ -38,6 +39,7 @@ from launch.actions import (
     SetEnvironmentVariable,
 )
 from launch.event_handlers import OnProcessExit, OnShutdown
+from launch.launch_description_sources import AnyLaunchDescriptionSource
 from launch_ros.actions import LifecycleNode as LifecycleNodeLaunchAction
 from launch_ros.actions import Node as NodeLaunchAction
 from launch_ros.actions import PushRosNamespace
@@ -1702,6 +1704,112 @@ class Launcher:
         )
 
         self._description.add_action(exec_process)
+
+    def add_ros_node(
+        self,
+        package: str,
+        executable: str,
+        name: Optional[str] = None,
+        parameters: Optional[List] = None,
+        remappings: Optional[List[Tuple[str, str]]] = None,
+        arguments: Optional[List[str]] = None,
+        output: str = "screen",
+        **launch_node_kwargs,
+    ) -> NodeLaunchAction:
+        """
+        Adds an external ROS2 node to the launcher, to be launched alongside
+        the components (e.g. a MoveIt move_group node, a camera driver).
+
+        The node always runs in its own process and inherits the Launcher
+        namespace (if one is set). The monitor does not track this node, so to
+        restart the node automatically if it dies, pass the launch_ros keyword
+        arguments ``respawn=True`` and optionally ``respawn_delay=<seconds>``.
+
+        :param package: Name of the ROS2 package containing the node executable
+        :type package: str
+        :param executable: Name of the node executable
+        :type executable: str
+        :param name: Node name, defaults to the executable's default name
+        :type name: Optional[str]
+        :param parameters: Node parameters (list of dicts and/or yaml file paths)
+        :type parameters: Optional[List]
+        :param remappings: Topic/service remapping pairs
+        :type remappings: Optional[List[Tuple[str, str]]]
+        :param arguments: Extra command line arguments for the node
+        :type arguments: Optional[List[str]]
+        :param output: Output configuration, defaults to 'screen'
+        :type output: str
+        :param launch_node_kwargs: Additional keyword arguments for launch_ros Node
+        :return: The created launch action
+        :rtype: launch_ros.actions.Node
+        """
+        node_action = NodeLaunchAction(
+            package=package,
+            executable=executable,
+            name=name,
+            parameters=parameters,
+            remappings=remappings,
+            arguments=arguments,
+            output=output,
+            **launch_node_kwargs,
+        )
+        self._description.add_action(node_action)
+        return node_action
+
+    def include_launch_file(
+        self,
+        package: Optional[str],
+        launch_file: str,
+        launch_args: Optional[Dict[str, Any]] = None,
+    ) -> IncludeLaunchDescription:
+        """
+        Includes an external launch file in the launcher, to be brought up
+        alongside the components (e.g. a robot's MoveIt config demo launch).
+
+        Python, XML and YAML launch files are supported. The included
+        description inherits the Launcher namespace (if one is set).
+
+        :param package: Name of the ROS2 package containing the launch file.
+            The file is resolved against the package share directory (directly
+            or under 'launch/'). If None, launch_file is used as a filesystem path
+        :type package: Optional[str]
+        :param launch_file: Launch file name (or path when package is None)
+        :type launch_file: str
+        :param launch_args: Launch arguments passed to the included launch file
+        :type launch_args: Optional[Dict[str, Any]]
+        :raises FileNotFoundError: If the launch file cannot be resolved
+        :return: The created launch action
+        :rtype: launch.actions.IncludeLaunchDescription
+        """
+        if package:
+            from ament_index_python.packages import get_package_share_directory
+
+            share_dir = get_package_share_directory(package)
+            candidates = [
+                os.path.join(share_dir, "launch", launch_file),
+                os.path.join(share_dir, launch_file),
+            ]
+            launch_path = next(
+                (path for path in candidates if os.path.isfile(path)), None
+            )
+            if launch_path is None:
+                raise FileNotFoundError(
+                    f"Launch file '{launch_file}' not found in package "
+                    f"'{package}' (looked in {candidates})"
+                )
+        else:
+            launch_path = launch_file
+            if not os.path.isfile(launch_path):
+                raise FileNotFoundError(f"Launch file '{launch_path}' not found")
+
+        include_action = IncludeLaunchDescription(
+            AnyLaunchDescriptionSource(launch_path),
+            launch_arguments=[
+                (key, str(value)) for key, value in (launch_args or {}).items()
+            ],
+        )
+        self._description.add_action(include_action)
+        return include_action
 
     def add_method(
         self,

--- a/test/base_attrs_test.py
+++ b/test/base_attrs_test.py
@@ -39,6 +39,7 @@ class SampleCfg(BaseAttrs):
     flag: bool = field(default=False)
     optional_int: Optional[int] = field(default=None)
     mode: Literal["a", "b", "c"] = field(default="a")
+    optional_mode: Optional[Literal["a", "b", "c"]] = field(default=None)
     either: Union[int, str] = field(default=0)
     array: np.ndarray = field(default=np.array([0.0, 0.0]))
     nested: NestedCfg = field(factory=NestedCfg)
@@ -90,6 +91,21 @@ def test_from_dict_literal_accepts_allowed_rejects_disallowed():
     assert cfg.mode == "b"
     with pytest.raises(TypeError):
         cfg.from_dict({"mode": "not_in_literal"})
+
+
+def test_from_dict_optional_literal_accepts_none_and_values():
+    """A Literal arm inside a Union is matched by value, not isinstance."""
+    cfg = SampleCfg()
+    cfg.from_dict({"optional_mode": "b"})
+    assert cfg.optional_mode == "b"
+    cfg.from_dict({"optional_mode": None})
+    assert cfg.optional_mode is None
+
+
+def test_from_dict_optional_literal_rejects_disallowed_value():
+    cfg = SampleCfg()
+    with pytest.raises(TypeError):
+        cfg.from_dict({"optional_mode": "not_in_literal"})
 
 
 def test_from_dict_list_to_ndarray_conversion():

--- a/test/external_launch_test.py
+++ b/test/external_launch_test.py
@@ -1,0 +1,58 @@
+"""Tests for launching external ROS2 nodes and launch files via the Launcher.
+
+Covers Launcher.add_ros_node and Launcher.include_launch_file — used by
+recipes to bring up nodes such as a MoveIt move_group alongside components.
+"""
+
+import pytest
+from launch.actions import IncludeLaunchDescription
+from launch_ros.actions import Node as NodeLaunchAction
+
+from ros_sugar import Launcher
+
+
+@pytest.fixture
+def launcher():
+    return Launcher()
+
+
+def test_add_ros_node_appends_action(launcher):
+    action = launcher.add_ros_node(
+        package="demo_nodes_cpp",
+        executable="talker",
+        name="my_talker",
+        remappings=[("chatter", "/chat")],
+    )
+    assert isinstance(action, NodeLaunchAction)
+    assert action in launcher._description.entities
+
+
+def test_include_launch_file_from_path(launcher, tmp_path):
+    launch_file = tmp_path / "external.launch.py"
+    launch_file.write_text(
+        "from launch import LaunchDescription\n"
+        "def generate_launch_description():\n"
+        "    return LaunchDescription()\n"
+    )
+    action = launcher.include_launch_file(
+        package=None, launch_file=str(launch_file), launch_args={"use_rviz": False}
+    )
+    assert isinstance(action, IncludeLaunchDescription)
+    assert action in launcher._description.entities
+    # launch args are stringified for the launch system
+    assert ("use_rviz", "False") in [tuple(pair) for pair in action.launch_arguments]
+
+
+def test_include_launch_file_missing_file_raises(launcher):
+    with pytest.raises(FileNotFoundError):
+        launcher.include_launch_file(
+            package=None, launch_file="/nonexistent.launch.py"
+        )
+
+
+def test_include_launch_file_missing_in_package_raises(launcher):
+    # automatika_ros_sugar is installed but has no such launch file
+    with pytest.raises(FileNotFoundError):
+        launcher.include_launch_file(
+            package="automatika_ros_sugar", launch_file="no_such.launch.py"
+        )

--- a/test/io_types_test.py
+++ b/test/io_types_test.py
@@ -11,6 +11,8 @@ Sections, one per message type:
   extraction in world frame, UI content
 - MultiArray: layout-driven reshaping
 - Image: raw buffer decoding
+- CameraInfo: CameraInfoCallback -> CameraIntrinsics, rectification,
+  binning and region of interest corrections
 - Path: UI downsampling
 - Zero-copy contract: dtype/contiguity the kompass-core bindings map
   without copying
@@ -25,11 +27,12 @@ import pytest
 from geometry_msgs.msg import Pose as ROSPose
 from geometry_msgs.msg import PoseArray, PoseStamped, TransformStamped
 from nav_msgs.msg import Odometry, OccupancyGrid, Path
-from sensor_msgs.msg import Image, LaserScan, PointCloud2, PointField
+from sensor_msgs.msg import CameraInfo, Image, LaserScan, PointCloud2, PointField
 from std_msgs.msg import Float32MultiArray, MultiArrayDimension
 
 from ros_sugar.io import Topic, get_msg_type
 from ros_sugar.io.callbacks import (
+    CameraInfoCallback,
     ImageCallback,
     LaserScanCallback,
     OccupancyGridCallback,
@@ -40,7 +43,12 @@ from ros_sugar.io.callbacks import (
     PoseStampedCallback,
     StdMsgArrayCallback,
 )
-from ros_sugar.io.datatypes import LaserScanData, PointCloudData
+from ros_sugar.io.datatypes import (
+    CameraIntrinsics,
+    LaserScanData,
+    PointCloudData,
+    read_camera_info,
+)
 from ros_sugar.io import supported_types
 
 
@@ -1104,3 +1112,107 @@ def test_zero_copy_grid_obstacles_survive_transform():
         transformation=_tf((1.0, 2.0, 0.0), quarter_turn)
     )
     _assert_cartesian_points(output)
+
+
+# ---------------------------------------------------------------------------
+# CameraInfo
+# ---------------------------------------------------------------------------
+
+
+def _camera_info(width=640, height=480, focal=500.0, with_projection=True):
+    info = CameraInfo()
+    info.header.frame_id = "front_optical"
+    info.width, info.height = width, height
+    cx, cy = width / 2, height / 2
+    info.k = [focal, 0.0, cx, 0.0, focal, cy, 0.0, 0.0, 1.0]
+    if with_projection:
+        info.p = [focal, 0.0, cx, 0.0, 0.0, focal, cy, 0.0, 0.0, 0.0, 1.0, 0.0]
+    info.distortion_model = "plumb_bob"
+    info.d = [0.0] * 5
+    return info
+
+
+def test_camera_info_reads_pinhole_parameters():
+    intrinsics = read_camera_info(_camera_info())
+    assert (intrinsics.fx, intrinsics.fy) == (500.0, 500.0)
+    assert (intrinsics.cx, intrinsics.cy) == (320.0, 240.0)
+    assert (intrinsics.width, intrinsics.height) == (640, 480)
+    assert intrinsics.frame_id == "front_optical"
+    assert intrinsics.distortion_model == "plumb_bob"
+
+
+def test_camera_info_prefers_the_rectified_projection():
+    """P describes the rectified image, which is what a rectified stream must
+    be deprojected with."""
+    info = _camera_info()
+    info.p[0], info.p[5] = 400.0, 400.0
+    assert read_camera_info(info).fx == 400.0
+
+
+def test_camera_info_falls_back_to_k_without_projection():
+    intrinsics = read_camera_info(_camera_info(with_projection=False))
+    assert (intrinsics.fx, intrinsics.cx) == (500.0, 320.0)
+
+
+def test_camera_info_binning_scales_with_the_image():
+    info = _camera_info()
+    info.binning_x = info.binning_y = 2
+    intrinsics = read_camera_info(info)
+    assert (intrinsics.fx, intrinsics.fy) == (250.0, 250.0)
+    assert (intrinsics.cx, intrinsics.cy) == (160.0, 120.0)
+    assert (intrinsics.width, intrinsics.height) == (320, 240)
+
+
+def test_camera_info_region_of_interest_moves_the_principal_point():
+    info = _camera_info()
+    info.roi.x_offset, info.roi.y_offset = 100, 50
+    info.roi.width, info.roi.height = 400, 300
+    intrinsics = read_camera_info(info)
+    assert (intrinsics.cx, intrinsics.cy) == (220.0, 190.0)
+    assert (intrinsics.width, intrinsics.height) == (400, 300)
+
+
+def test_camera_info_matrix_and_accessors():
+    intrinsics = read_camera_info(_camera_info())
+    assert intrinsics.matrix[0][0] == 500.0 and intrinsics.matrix[2][2] == 1.0
+    assert list(intrinsics.focal_length) == [500.0, 500.0]
+    assert list(intrinsics.principal_point) == [320.0, 240.0]
+
+
+def test_camera_info_matches_image_size():
+    intrinsics = read_camera_info(_camera_info())
+    assert intrinsics.matches(640, 480)
+    assert not intrinsics.matches(1280, 720)
+
+
+def test_camera_info_callback_returns_intrinsics():
+    callback = _fed_callback(CameraInfoCallback, "CameraInfo", _camera_info())
+    intrinsics = callback.get_output()
+    assert isinstance(intrinsics, CameraIntrinsics)
+    assert intrinsics.fx == 500.0
+
+
+def test_camera_info_callback_no_message_returns_none():
+    assert _fed_callback(CameraInfoCallback, "CameraInfo").get_output() is None
+
+
+def test_camera_info_reused_until_the_camera_changes():
+    callback = _fed_callback(CameraInfoCallback, "CameraInfo", _camera_info())
+    first = callback.get_output()
+    assert callback.get_output() is first
+
+    callback.callback(_camera_info(width=1280, height=720))
+    assert callback.get_output() is not first
+    assert callback.get_output().width == 1280
+
+
+def test_camera_info_ui_content():
+    callback = _fed_callback(CameraInfoCallback, "CameraInfo", _camera_info())
+    content = callback._get_ui_content()
+    assert "640x480" in content and "front_optical" in content
+
+
+def test_camera_info_type_registration():
+    assert _topic("CameraInfo").msg_type is supported_types.CameraInfo
+    info = _camera_info()
+    assert supported_types.CameraInfo.convert(info) is info

--- a/test/io_types_test.py
+++ b/test/io_types_test.py
@@ -1206,6 +1206,34 @@ def test_camera_info_reused_until_the_camera_changes():
     assert callback.get_output().width == 1280
 
 
+def test_camera_info_cache_follows_a_binning_change():
+    """width, height, K and P are calibration-frame values and stay
+    byte-identical when the driver turns on binning — only binning_x/y move,
+    so they must be part of the cache key."""
+    callback = _fed_callback(CameraInfoCallback, "CameraInfo", _camera_info())
+    assert callback.get_output().fx == 500.0
+
+    binned = _camera_info()
+    binned.binning_x = binned.binning_y = 2
+    callback.callback(binned)
+
+    intrinsics = callback.get_output()
+    assert intrinsics.fx == 250.0
+    assert (intrinsics.width, intrinsics.height) == (320, 240)
+
+
+def test_camera_info_cache_follows_a_roi_change():
+    callback = _fed_callback(CameraInfoCallback, "CameraInfo", _camera_info())
+    assert callback.get_output().cx == 320.0
+
+    cropped = _camera_info()
+    cropped.roi.x_offset, cropped.roi.y_offset = 100, 50
+    cropped.roi.width, cropped.roi.height = 400, 300
+    callback.callback(cropped)
+
+    assert callback.get_output().cx == 220.0
+
+
 def test_camera_info_ui_content():
     callback = _fed_callback(CameraInfoCallback, "CameraInfo", _camera_info())
     content = callback._get_ui_content()

--- a/test/io_types_test.py
+++ b/test/io_types_test.py
@@ -1154,6 +1154,26 @@ def test_camera_info_falls_back_to_k_without_projection():
     assert (intrinsics.fx, intrinsics.cx) == (500.0, 320.0)
 
 
+def test_camera_info_rectified_intrinsics_carry_no_distortion():
+    """P describes the rectified image, where rectification already removed
+    the distortion — pairing P's focal length with the raw image's
+    coefficients would describe no real camera."""
+    info = _camera_info()
+    info.d = [0.1, -0.2, 0.001, 0.002, 0.05]
+    intrinsics = read_camera_info(info)
+    assert intrinsics.distortion.size == 0
+    # the model stays as reported sensor metadata
+    assert intrinsics.distortion_model == "plumb_bob"
+
+
+def test_camera_info_raw_intrinsics_keep_their_distortion():
+    info = _camera_info(with_projection=False)
+    info.d = [0.1, -0.2, 0.001, 0.002, 0.05]
+    intrinsics = read_camera_info(info)
+    assert list(intrinsics.distortion) == [0.1, -0.2, 0.001, 0.002, 0.05]
+    assert intrinsics.distortion_model == "plumb_bob"
+
+
 def test_camera_info_binning_scales_with_the_image():
     info = _camera_info()
     info.binning_x = info.binning_y = 2


### PR DESCRIPTION
Infrastructure needed by the EmbodiedAgents MoveIt integration, plus two config-layer fixes surfaced by it.

## Features

- `Launcher.add_ros_node` / `include_launch_file`: recipes can bring up external ROS nodes and launch files (e.g. a robot's MoveIt configuration) alongside sugarcoat components.
- `CameraIntrinsics` datatype in `ros_sugar.io`, with `read_camera_info` to parse a `sensor_msgs/CameraInfo` — lifted upstream so any consumer of camera calibration shares one type.

## Fixes

- `BaseAttrs` deserialization crashed on any field typed `Union` with a `Literal` arm (e.g. `Optional[Literal[...]]`): the type gate called `isinstance` against a subscripted generic, which Python forbids — for every value, valid ones included. Literal arms are now matched by value, other arms by `isinstance`, and `Optional[Literal]` fields actually validate for the first time. Regression tests included.
- `base_validators.in_` retyped generically (`List[_T] -> Callable[[Any, Any, _T], None]`): the concrete alias broke Pyright's inference of `Literal` fields through `attrs.field()` in every downstream config.
- Callbacks check for the fixed-input attribute at init; type annotation fix in the base client; debug-logging fix in request sending.