### PR TITLE
Plugin-declared driver processes, shared-memory feedback for large payloads, and launch prefixes

### DIFF
--- a/docs/development/custom_robot_plugin.md
+++ b/docs/development/custom_robot_plugin.md
@@ -236,6 +236,57 @@ class _MyRobotForTest(MyRobotPlugin):
 The serializable plugin spec captures whichever subclass and kwargs were used,
 so the same override survives the multiprocess launch boundary.
 
+### Bringing Up a Driver Node
+
+Some feedback is only real if a separate process is running: a LiDAR's points
+come from the vendor's driver node, not from the plugin. Which driver that is,
+and how it must be configured, is exactly the robot-specific knowledge the
+plugin exists to absorb — so declare it on the plugin rather than making every
+recipe start it by hand.
+
+Override `required_processes()` and return a `ProcessSpec` per node. The
+launcher brings them up through the same machinery as `Launcher.add_ros_node`,
+which means they get respawn, captured output, and teardown ordered with the
+rest of the recipe:
+
+```python
+from ros_sugar.robot import ProcessSpec
+
+class MyRobotPlugin(RobotPlugin):
+    def required_processes(self):
+        # Only pay for the driver if the recipe actually reads the points
+        if not {"lidar_front", "lidar_back"} & self.requested_feedbacks:
+            return []
+        return [
+            ProcessSpec(
+                package="rslidar_sdk",
+                executable="rslidar_sdk_node",
+                parameters=[self.LIDAR_CONFIG],
+                precondition=self._lidar_port_is_free,
+            )
+        ]
+```
+
+`requested_feedbacks` and `requested_commands` hold the keys the recipe's
+components actually consume, resolved from their `Topic(use_plugin=...)`
+references. A plugin usually exposes more than any one recipe needs; this is
+how it tells the difference. Both are populated before `required_processes()`
+and `on_attached()` run, and are empty when there is no launcher — a plugin
+nobody asked anything of should provide nothing, not everything.
+
+```{caution}
+Set a `precondition` for any driver that claims an exclusive resource. Most
+LiDAR drivers bind a fixed UDP port and cannot coexist with a second copy of
+themselves, and many robots already start the vendor's own instance at boot.
+A second one comes up cleanly and then simply never publishes — which reads as
+a crash and sends people looking in the wrong place. Return `False` when the
+existing instance is detected.
+```
+
+Declare processes; do not start them. A plugin that spawned its own subprocess
+would sit outside the launch system: no respawn, no captured output, no ordered
+shutdown, and a process still holding the device if the launcher is killed.
+
 ## Describing the Robot
 
 A `RobotPlugin` knows the robot it drives, so it can configure the whole stack:

--- a/docs/development/custom_robot_plugin.md
+++ b/docs/development/custom_robot_plugin.md
@@ -301,7 +301,7 @@ class MyRobotPlugin(RobotPlugin):
             geometry_params=[0.61, 0.37, 0.4],
             ctrl_vx_limits=LinearCtrlLimits(max_vel=1.0, max_acc=2.5, max_decel=7.5),
             ctrl_omega_limits=AngularCtrlLimits(
-                max_vel=1.5, max_acc=2.5, max_decel=4.0, max_steer=1.57
+                max_omega=1.5, max_acc=2.5, max_decel=4.0, max_ang=1.57
             ),
         )
         self.base_frame = "base_link"

--- a/ros_sugar/config/robot.py
+++ b/ros_sugar/config/robot.py
@@ -121,7 +121,8 @@ class LinearCtrlLimits(BaseAttrs):
     max_vel: float = field(validator=validators.ge(0.0))  # m/s
     max_acc: float = field(validator=validators.ge(0.0))  # m/s^2
     max_decel: float = field(validator=validators.ge(0.0))  # m/s^2
-    min_absolute_val: float = field(default=0.01, validator=validators.ge(0.0))
+    # Smallest speed the robot executes; commands below it are zeroed (m/s)
+    min_vel: float = field(default=0.05, validator=validators.ge(0.0))
 
 
 @define(kw_only=True)

--- a/ros_sugar/config/robot.py
+++ b/ros_sugar/config/robot.py
@@ -116,24 +116,45 @@ def _to_enum(enum_cls, value):
 
 @define(kw_only=True)
 class LinearCtrlLimits(BaseAttrs):
-    """Linear velocity control limits along one axis"""
+    """Linear velocity control limits along one axis.
+
+    This class is a copy of ``LinearVelocityControlParams`` in kompass-core
+    (``kompass_cpp.control``), kept here so that a recipe can be written
+    without depending on the core library. The two must be kept in sync.
+
+    The maxima and accelerations accept zero on purpose: a robot without a
+    lateral axis declares it as all-zero limits (see the default of
+    ``RobotConfig.ctrl_vy_limits``). Only the minimum is strictly positive,
+    since a zero minimum is no deadband at all.
+    """
 
     max_vel: float = field(validator=validators.ge(0.0))  # m/s
     max_acc: float = field(validator=validators.ge(0.0))  # m/s^2
     max_decel: float = field(validator=validators.ge(0.0))  # m/s^2
-    # Smallest speed the robot executes; commands below it are zeroed (m/s)
-    min_vel: float = field(default=0.05, validator=validators.ge(0.0))
+    # Smallest speed the robot executes; commands below it are zeroed (m/s).
+    min_vel: float = field(default=0.05, validator=validators.gt(0.0))
 
 
 @define(kw_only=True)
 class AngularCtrlLimits(BaseAttrs):
-    """Angular velocity control limits"""
+    """Angular velocity control limits.
 
-    max_vel: float = field(validator=validators.ge(0.0))  # rad/s
-    max_steer: float = field(validator=validators.ge(0.0))  # rad
+    This class is a copy of ``AngularVelocityControlParams`` in kompass-core
+    (``kompass_cpp.control``), kept here so that a recipe can be written
+    without depending on the core library. The two must be kept in sync.
+
+    The maxima and accelerations accept zero for the same reason as in
+    ``LinearCtrlLimits``: an axis a robot does not have is declared with
+    all-zero limits. Only the minimum is strictly positive, since a zero
+    minimum is no deadband at all.
+    """
+
+    max_omega: float = field(validator=validators.ge(0.0))  # rad/s
+    max_ang: float = field(validator=validators.ge(0.0))  # rad, steering angle
     max_acc: float = field(validator=validators.ge(0.0))  # rad/s^2
     max_decel: float = field(validator=validators.ge(0.0))  # rad/s^2
-    min_absolute_val: float = field(default=0.01, validator=validators.ge(0.0))
+    # Smallest rate the robot executes; commands below it are zeroed (rad/s).
+    min_omega: float = field(default=0.01, validator=validators.gt(0.0))
 
 
 @define(kw_only=True)

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -201,6 +201,9 @@ class BaseComponent(lifecycle.Node):
         self._plugins: Dict[str, Any] = {}
         # Names of input/output topics bound to non-ROS robot plugin transports
         self._external_topics: set = set()
+        # Recipe topic name -> ROS topic its subscriber is created on, for
+        # inputs a robot plugin serves over a ROS topic of its own
+        self._plugin_ros_topics: Dict[str, str] = {}
         # Feedback-bus subscription handles to release on deactivation
         self._robot_plugin_bus_handles: List = []
 
@@ -436,16 +439,7 @@ class BaseComponent(lifecycle.Node):
                 continue
             transport = feedback.transport
             if isinstance(transport, RosTopicTransport):
-                if topic.name != transport.topic_name:
-                    self.get_logger().info(
-                        f"Robot plugin remaps input '{topic.name}' "
-                        f"({topic.msg_type.__name__}) to '{transport.topic_name}'"
-                    )
-                error = self._replace_input_topic(
-                    topic.name, transport.topic_name, transport.msg_type
-                )
-                if error:
-                    self.get_logger().error(error)
+                self._bind_ros_feedback(topic, feedback, transport)
             else:
                 self._attach_external_feedback(topic, feedback, plugin)
 
@@ -490,6 +484,40 @@ class BaseComponent(lifecycle.Node):
             else:
                 self._replace_output_by_transport(topic, command, plugin)
 
+    def _bind_ros_feedback(self, topic: Topic, feedback, transport) -> None:
+        """Serve an input from the ROS topic a robot plugin publishes it on.
+
+        The recipe's topic name stays the input's identity. Only the subscription
+        points at the plugin's topic, with the plugin's message type and QoS,
+        the way `_attach_external_feedback` keeps the name for non-ROS transports.
+
+        :param topic: The component input topic being adapted.
+        :param feedback: The `robot.feedback.Feedback` to bind.
+        :param transport: Its `robot.transports.RosTopicTransport`.
+        """
+        old_callback = self.callbacks.get(topic.name)
+        if old_callback is None:
+            self.get_logger().error(
+                f"Cannot bind robot feedback: no callback slot for input '{topic.name}'"
+            )
+            return
+        new_topic = Topic(
+            name=topic.name,
+            msg_type=transport.msg_type,
+            qos_profile=transport.qos,
+            use_plugin=topic.use_plugin,
+        )
+        new_callback = new_topic.msg_type.callback(new_topic, node_name=self.node_name)
+        # Adaptation runs before the subscribers are created; this is where
+        # the input's subscriber will be pointed
+        self._plugin_ros_topics[topic.name] = transport.topic_name
+        self.callbacks[topic.name] = new_callback
+        self._update_inactive_input_topic(old_callback.input_topic, new_topic)
+        self.get_logger().info(
+            f"Input '{topic.name}' bound to robot plugin feedback "
+            f"'{feedback.key}' via ROS topic '{transport.topic_name}'"
+        )
+
     def _attach_external_feedback(self, topic: Topic, feedback, plugin) -> None:
         """Bind a non-ROS robot feedback stream into the component's callback slot.
 
@@ -502,8 +530,7 @@ class BaseComponent(lifecycle.Node):
         component's originally-declared input type (e.g. a manufacturer's custom
         message standing in for ``Odometry``). The component's callback object
         is therefore swapped for one of ``feedback.msg_type``, keeping the
-        original topic name as the ``callbacks`` dict key - exactly as
-        `_replace_input_topic` does for ROS-topic feedback.
+        original topic name as the ``callbacks`` dict key.
 
         :param topic: The component input topic being adapted.
         :param feedback: The `robot.feedback.Feedback` to bind.
@@ -723,15 +750,19 @@ class BaseComponent(lifecycle.Node):
         :param callback:
         :type callback: GenericCallback
         """
+        name = callback.input_topic.name
+        topic = self._plugin_ros_topics.get(name, name)  # for topics coming from plugins
         _subscriber = self.create_subscription(
             msg_type=callback.input_topic.ros_msg_type,
-            topic=callback.input_topic.name,
+            topic=topic,
             qos_profile=callback.input_topic.qos_profile.to_ros(),
             callback=callback.callback,
             callback_group=self.callback_group,
         )
         self.get_logger().debug(
-            f"Started subscriber to topic: {callback.input_topic.name} of type {callback.input_topic.msg_type}"
+            f"Started subscriber to topic: {topic} of type "
+            f"{callback.input_topic.msg_type}"
+            + (f" for input '{name}'" if topic != name else "")
         )
         return _subscriber
 
@@ -2449,6 +2480,10 @@ class BaseComponent(lifecycle.Node):
     ) -> Optional[str]:
         """Replaces a component input topic by a new topic
 
+        The explicit swap behind the ReplaceTopic service. The input's identity
+        changes, so the callbacks dict is re-keyed by the new name and
+        ``in_topics`` is updated to match.
+
         :param topic_name: Old Topic name
         :type topic_name: str
         :param new_name: New topic name
@@ -2487,7 +2522,9 @@ class BaseComponent(lifecycle.Node):
 
             new_callback.set_subscriber(self._add_ros_subscriber(new_callback))
 
-        # Update callbacks dictionary.
+        # Update callbacks dictionary. The plugin's binding was to the name
+        # being retired thus remove that here as well
+        self._plugin_ros_topics.pop(normalized_topic_name, None)
         self.callbacks.pop(normalized_topic_name)
         self.callbacks[new_topic.name] = new_callback
 

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -181,6 +181,10 @@ class BaseComponent(lifecycle.Node):
         # Additional types from derived packages
         self._additional_types: List[Type[SupportedType]] = []
 
+        # Command prefix for this component's process in multiprocess launch,
+        # e.g. "taskset -c 4-7", "nice -n 10" or "perf record".
+        self.launch_prefix: Optional[str] = None
+
         # Plugins attached by the Launcher, keyed by plugin id (HOST instances
         # in multithreaded launch, reconstructed CLIENT instances in
         # multiprocess launch)

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -3072,7 +3072,16 @@ class BaseComponent(lifecycle.Node):
             elif self.__fallbacks.on_any_fail:
                 self.__fallbacks_giveup = self.__fallbacks.execute_generic_fallback()
 
-            # Update the health status from the fallback after execution
+            else:
+                # No policy is defined for this failure, so there is no fallback
+                # status to adopt.
+                self.get_logger().warning(
+                    "No fallback policy is defined for detected failure -> Failure is broadcasted",
+                    once=True,
+                )
+                return
+
+            # Update the health status from the fallback that just ran
             self.health_status.value = self.__fallbacks.latest_status
 
         except ValueError:

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -815,16 +815,19 @@ class BaseComponent(lifecycle.Node):
         """
         Create required subscriptions, publications, timers, ... etc. to activate the node
         """
-        # Init any global node variables
-        self.init_variables()
-
-        # Adapt the component's topics to whichever plugins are attached. A
-        # recipe with none should never get here as the launcher fails at bringup.
-        # So this warns and keeps working for a standalone component.
+        # Adapt the component's topics to whichever plugins are attached.
+        # NOTE: Plugin adaptation MUST run before init_variables(), as it replaces
+        # entries in `self.callbacks` with new objects and destroys the old
+        # subscribers, so a component that caches callback references during
+        # init_variables() would be
+        # left holding orphans
         if self._plugins:
             self._use_robot_plugin()
         else:
             self._warn_orphaned_plugin_topics()
+
+        # Init any global node variables
+        self.init_variables()
 
         self.create_all_subscribers()
 

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -2452,9 +2452,9 @@ class BaseComponent(lifecycle.Node):
 
             new_callback.set_subscriber(self._add_ros_subscriber(new_callback))
 
-        # Update callbacks dictionary
+        # Update callbacks dictionary.
         self.callbacks.pop(normalized_topic_name)
-        self.callbacks[new_name] = new_callback
+        self.callbacks[new_topic.name] = new_callback
 
         # update the internal lists
         old_topic = old_callback.input_topic

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -1,65 +1,75 @@
 """Base Component"""
 
-import os
-import time
-import json
-import socket
-from copy import deepcopy
-from contextlib import contextmanager
-import threading
-from typing import Any, Dict, List, Optional, Union, Callable, Sequence, Tuple, Type
-from functools import wraps, partial
 import importlib
+import json
+import os
+import socket
+import threading
+import time
+from contextlib import contextmanager
+from copy import deepcopy
+from functools import partial, wraps
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
 
-from rclpy import logging as rclpy_logging
-from rclpy.action.server import ActionServer, CancelResponse, GoalResponse
-from rclpy.utilities import try_shutdown
 import rclpy.callback_groups as ros_callback_groups
-from rclpy.callback_groups import MutuallyExclusiveCallbackGroup, ReentrantCallbackGroup
-from rclpy import lifecycle
-from rclpy.lifecycle.node import TransitionCallbackReturn, LifecycleState
-from rclpy.publisher import Publisher as ROSPublisher
-from rclpy.subscription import Subscription
-from rclpy.client import Client
-from tf2_ros.buffer import Buffer
-from tf2_ros.transform_listener import TransformListener
-from builtin_interfaces.msg import Time
-from geometry_msgs.msg import TransformStamped
-from lifecycle_msgs.msg import State as LifecycleStateMsg
-
 from automatika_ros_sugar.srv import (
     ChangeParameter,
     ChangeParameters,
     ConfigureFromFile,
-    ReplaceTopic,
     ExecuteMethod,
+    ReplaceTopic,
 )
+from builtin_interfaces.msg import Time
+from geometry_msgs.msg import TransformStamped
+from lifecycle_msgs.msg import State as LifecycleStateMsg
+from rclpy import lifecycle
+from rclpy import logging as rclpy_logging
+from rclpy.action.server import ActionServer, CancelResponse, GoalResponse
+from rclpy.callback_groups import MutuallyExclusiveCallbackGroup, ReentrantCallbackGroup
+from rclpy.client import Client
+from rclpy.lifecycle.node import LifecycleState, TransitionCallbackReturn
+from rclpy.publisher import Publisher as ROSPublisher
+from rclpy.subscription import Subscription
+from rclpy.utilities import try_shutdown
+from tf2_ros.buffer import Buffer
+from tf2_ros.transform_listener import TransformListener
 
-from .action import Action
-from .event import Event, EventBlackboardEntry
-from ..io.callbacks import GenericCallback
+from ..base_clients import ActionClientConfig
 from ..config.base_attrs import explicit_fields
 from ..config.base_config import (
+    BaseAttrs,
     BaseComponentConfig,
     ComponentRunType,
     ExternalProcessorType,
-    BaseAttrs,
     QoSConfig,
 )
-from ..io.topic import Topic
-from ..io.supported_types import SupportedType
+from ..io.callbacks import GenericCallback
 from ..io.publisher import Publisher
-from .fallbacks import ComponentFallbacks, Fallback
-from .status import Status
+from ..io.supported_types import SupportedType
+from ..io.topic import Topic
+from ..tf import TFListener, TFListenerConfig
 from ..utils import (
     camel_to_snake_case,
-    component_fallback,
     component_action,
+    component_fallback,
     get_methods_with_decorator,
     log_srv,
 )
-from ..base_clients import ActionClientConfig
-from ..tf import TFListener, TFListenerConfig
+from .action import Action
+from .event import Event, EventBlackboardEntry
+from .fallbacks import ComponentFallbacks, Fallback
+from .status import Status
 
 
 class BaseComponent(lifecycle.Node):
@@ -202,6 +212,8 @@ class BaseComponent(lifecycle.Node):
         # Input topic name -> (goal frame, is the mount rigid). Declared by the
         # component (usually in init_variables)
         self._input_frame_targets: Dict[str, Tuple[str, bool]] = {}
+        # Keys already reported through log_once
+        self._logged_once: Set[str] = set()
 
         # To use without launcher -> Init the ROS2 node directly
         if self.config._use_without_launcher:
@@ -590,9 +602,7 @@ class BaseComponent(lifecycle.Node):
         for config in configs:
             # Only apply fields actually set, not a full snapshot. So fields set
             # by the component itself are not written over
-            self._algorithms_config[config.__class__.__name__] = explicit_fields(
-                config
-            )
+            self._algorithms_config[config.__class__.__name__] = explicit_fields(config)
 
     def _configure_algorithm(self, algo_config: BaseAttrs) -> BaseAttrs:
         """Configure an algorithm from the user defined configuration classes
@@ -1229,6 +1239,24 @@ class BaseComponent(lifecycle.Node):
         return self.get_transform_listener(
             source_frame, goal_frame, static_tf
         ).transform
+
+    def log_once(self, key: str, message: str, level: str = "warning") -> None:
+        """Log a lasting condition the first time it is seen under `key`.
+
+        Use instead of rclpy's `once=True` which mutes by call site
+
+        :param key: Name of the condition, unique within the component
+        :type key: str
+        :param message: What to log the first time the condition is seen
+        :type message: str
+        :param level: Logger method to use: 'debug', 'info', 'warning',
+            'error' or 'fatal'
+        :type level: str
+        """
+        if key in self._logged_once:
+            return
+        self._logged_once.add(key)
+        getattr(self.get_logger(), level)(message)
 
     def transform_input_to(
         self, topic_name: str, goal_frame: str, static_tf: bool = False

--- a/ros_sugar/core/status.py
+++ b/ros_sugar/core/status.py
@@ -122,6 +122,10 @@ class Status:
         Set status to Running - Healthy
         """
         self._set_status_from_dict(key=0)
+        # Clear any previous failure sources
+        self._msg.src_algorithms = []
+        self._msg.src_components = []
+        self._msg.src_topics = []
 
     def set_failure(self):
         """

--- a/ros_sugar/io/callbacks.py
+++ b/ros_sugar/io/callbacks.py
@@ -12,7 +12,7 @@ import numpy as np
 from geometry_msgs.msg import Pose, PoseStamped
 from jinja2.environment import Template
 from nav_msgs.msg import OccupancyGrid, Odometry, Path
-from sensor_msgs.msg import CameraInfo, Imu, JointState, LaserScan, NavSatFix, Range
+from sensor_msgs.msg import LaserScan
 from std_msgs.msg import Header
 from rclpy.logging import get_logger
 from rclpy.subscription import Subscription
@@ -577,6 +577,7 @@ class OdomCallback(GenericCallback):
         odom_in_map_pose_data.pose.pose.position.y = transform.transform.translation.y
         odom_in_map_pose_data.pose.pose.position.z = transform.transform.translation.z
         odom_in_map_pose_data.pose.pose.orientation = transform.transform.rotation
+        odom_in_map_pose_data.twist.twist = msg.twist.twist
 
         odom_in_goal_pose_data: Odometry = utils.odom_from_frame1_to_frame2(
             pose_1_in_2=odom_in_map_pose_data, pose_target_in_1=msg

--- a/ros_sugar/io/datatypes.py
+++ b/ros_sugar/io/datatypes.py
@@ -1,7 +1,7 @@
 """Data containers for ROS message payloads processed by callbacks."""
 
 import math
-from typing import List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 import numpy as np
 from attrs import Factory, define, field
@@ -169,6 +169,27 @@ class PointCloudData(BaseAttrs):
             return None
         self._xyz_cache = xyz[np.isfinite(xyz).all(axis=1)]
         return self._xyz_cache
+
+    def buffer_layout(self) -> Dict[str, Any]:
+        """The raw point buffer with the fields that describe it, as keyword
+        arguments for a raw-buffer consumer.
+
+        Unlike ``asdict()``, which returns every field of the container, nothing
+        else is included. The buffer is passed through, not copied, and nothing is decoded.
+
+        :return: Buffer and layout keyword arguments
+        :rtype: Dict[str, Any]
+        """
+        return {
+            "data": self.data,
+            "point_step": self.point_step,
+            "row_step": self.row_step,
+            "height": self.height,
+            "width": self.width,
+            "x_offset": self.x_offset,
+            "y_offset": self.y_offset,
+            "z_offset": self.z_offset,
+        }
 
     def filtered(
         self,

--- a/ros_sugar/io/supported_types.py
+++ b/ros_sugar/io/supported_types.py
@@ -46,7 +46,7 @@ from std_msgs.msg import (
 
 from . import callbacks
 from .utils import _convert_ros_scalar, _split_ros_field_type
-from .utils import numpy_to_multiarray
+from .utils import bytes_to_array, numpy_to_multiarray
 
 
 _additional_types = {}
@@ -480,7 +480,7 @@ class Image(SupportedType):
         msg = ROSImage()
         msg.height = output.shape[0]
         msg.width = output.shape[1]
-        msg.data = output.flatten()
+        msg.data = bytes_to_array(output.tobytes())
         return msg
 
     @classmethod
@@ -510,7 +510,7 @@ class Image(SupportedType):
         msg.encoding = meta["e"]
         msg.is_bigendian = bool(meta["b"])
         msg.step = meta["st"]
-        msg.data = buffer
+        msg.data = bytes_to_array(buffer)
         return msg
 
 
@@ -533,7 +533,7 @@ class CompressedImage(Image):
             return output
         msg = ROSCompressedImage()
         msg.format = "png"
-        msg.data = output.flatten()
+        msg.data = bytes_to_array(np.asarray(output).tobytes())
         return msg
 
     @classmethod
@@ -556,7 +556,7 @@ class CompressedImage(Image):
         msg.header.stamp.nanosec = meta["ns"]
         msg.header.frame_id = meta["f"]
         msg.format = meta["fmt"]
-        msg.data = buffer
+        msg.data = bytes_to_array(buffer)
         return msg
 
 
@@ -644,7 +644,7 @@ class PointCloud2(SupportedType):
             ROSPointField(name=n, offset=o, datatype=dt, count=c)
             for (n, o, dt, c) in meta["fl"]
         ]
-        msg.data = buffer
+        msg.data = bytes_to_array(buffer)
         return msg
 
 
@@ -772,7 +772,7 @@ class OccupancyGrid(SupportedType):
 
         # flatten by column
         # index (0,0) is the lower right corner of the grid in ROS
-        msg.data = output.flatten("F").astype(np.int8).tolist()
+        msg.data = bytes_to_array(output.flatten("F").astype(np.int8).tobytes(), "b")
         return msg
 
 

--- a/ros_sugar/io/supported_types.py
+++ b/ros_sugar/io/supported_types.py
@@ -2,6 +2,8 @@
 
 from typing import Any, Union, Optional, List, Dict, Tuple
 import base64
+import sys
+
 import numpy as np
 import importlib
 
@@ -45,8 +47,9 @@ from std_msgs.msg import (
 )
 
 from . import callbacks
+from .datatypes import CameraIntrinsics
 from .utils import _convert_ros_scalar, _split_ros_field_type
-from .utils import bytes_to_array, numpy_to_multiarray
+from .utils import bytes_to_array, image_encoding, numpy_to_multiarray, stamp_header
 
 
 _additional_types = {}
@@ -470,16 +473,39 @@ class Image(SupportedType):
     _ui_rate_sampled = True  # continuous frames; also inherited by CompressedImage
 
     @classmethod
-    def convert(cls, output: Union[ROSImage, np.ndarray], **_) -> ROSImage:
-        """
-        Takes a ROS Image message or numpy array and returns a ROS Image message
+    def convert(
+        cls,
+        output: Union[ROSImage, np.ndarray],
+        encoding: Optional[str] = None,
+        stamp: Optional[float] = None,
+        frame_id: str = "",
+        **_,
+    ) -> ROSImage:
+        """Passes a ROS Image through, or builds a complete one around an array.
+
+        The array is (H, W) or (H, W, C). ``encoding`` names the pixel layout
+        as the array holds it. When unset, it is inferred from the dtype and the
+        channel count.
+
+        ``stamp`` in seconds and ``frame_id`` are for callers building
+        messages outside a publisher.
+
         :return: ROSImage
         """
         if isinstance(output, ROSImage):
             return output
+        if output.ndim not in (2, 3):
+            raise ValueError(f"An image array is (H, W) or (H, W, C), got {output.shape}")
+        channels = 1 if output.ndim == 2 else output.shape[2]
+        if encoding is None:
+            encoding = image_encoding(output.dtype, channels)
         msg = ROSImage()
+        stamp_header(msg.header, stamp, frame_id)
         msg.height = output.shape[0]
         msg.width = output.shape[1]
+        msg.encoding = encoding
+        msg.is_bigendian = 0 if sys.byteorder == "little" else 1
+        msg.step = output.shape[1] * channels * output.dtype.itemsize
         msg.data = bytes_to_array(output.tobytes())
         return msg
 
@@ -683,13 +709,46 @@ class CameraInfo(SupportedType):
     # effectively static, so there is nothing to throttle
 
     @classmethod
-    def convert(cls, output: ROSCameraInfo, **_) -> ROSCameraInfo:
-        """
-        Passes a ROS CameraInfo message through.
+    def convert(
+        cls,
+        output: Union[ROSCameraInfo, CameraIntrinsics],
+        stamp: Optional[float] = None,
+        frame_id: str = "",
+        **_,
+    ) -> ROSCameraInfo:
+        """Passes a ROS CameraInfo through, or builds one from CameraIntrinsics
+        as the inverse of `read_camera_info`.
+
+        Intrinsics carrying distortion coefficients describe a raw image. They
+        go into ``K`` and ``D`` and ``P`` stays unset, so a reader falls back
+        to ``K``. Intrinsics without coefficients describe a rectified or
+        registered image go into ``P``, and into ``K`` as well since no
+        raw matrix is known.
+
+        ``stamp`` in seconds and ``frame_id`` override the intrinsics' own,
+        for callers building messages outside a publisher.
 
         :return: ROSCameraInfo
         """
-        return output
+        if isinstance(output, ROSCameraInfo):
+            return output
+        msg = ROSCameraInfo()
+        stamp_header(
+            msg.header,
+            output.timestamp if stamp is None else stamp,
+            frame_id or output.frame_id,
+        )
+        msg.width, msg.height = int(output.width), int(output.height)
+        msg.distortion_model = output.distortion_model
+        fx, fy, cx, cy = (float(v) for v in (output.fx, output.fy, output.cx, output.cy))
+        msg.k = [fx, 0.0, cx, 0.0, fy, cy, 0.0, 0.0, 1.0]
+        msg.r = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+        distortion = np.asarray(output.distortion, dtype=np.float64).ravel()
+        if distortion.size:
+            msg.d = distortion.tolist()
+        else:
+            msg.p = [fx, 0.0, cx, 0.0, 0.0, fy, cy, 0.0, 0.0, 0.0, 1.0, 0.0]
+        return msg
 
 
 class Imu(SupportedType):

--- a/ros_sugar/io/supported_types.py
+++ b/ros_sugar/io/supported_types.py
@@ -1,6 +1,6 @@
 """ROS Topics Supported Message Types"""
 
-from typing import Any, Union, Optional, List, Dict
+from typing import Any, Union, Optional, List, Dict, Tuple
 import base64
 import numpy as np
 import importlib
@@ -28,6 +28,7 @@ from sensor_msgs.msg import JointState as ROSJointState
 from sensor_msgs.msg import LaserScan as ROSLaserScan
 from sensor_msgs.msg import NavSatFix as ROSNavSatFix
 from sensor_msgs.msg import PointCloud2 as ROSPointCloud2
+from sensor_msgs.msg import PointField as ROSPointField
 from sensor_msgs.msg import Range as ROSRange
 
 # STD_MSGS SUPPORTED ROS TYPES
@@ -339,6 +340,29 @@ class SupportedType:
         """
         return cls._ros_type
 
+    @classmethod
+    def to_shm_payload(cls, msg: Any) -> Optional[Tuple[Dict, memoryview]]:
+        """Zero-copy hand-off for the shared-memory feedback fast path.
+
+        Return ``(meta, view)`` where ``view`` is a zero-copy ``memoryview`` of
+        the message's dominant buffer and ``meta`` carries everything
+        `from_shm_payload` needs to rebuild the message around a copy of it.
+        Return ``None`` (the default) for types that are not a good fit so the
+        caller falls back to CDR. Overridden on large, single-buffer types.
+        """
+        return None
+
+    @classmethod
+    def from_shm_payload(cls, meta: Dict, buffer: bytes) -> Any:
+        """Rebuild a ROS message from ``meta`` and a copy of the payload buffer.
+
+        Paired with `to_shm_payload`; only called for types that returned a
+        payload from it.
+        """
+        raise NotImplementedError(
+            f"{cls.__name__} does not implement from_shm_payload"
+        )
+
 
 class String(SupportedType):
     """String."""
@@ -459,6 +483,36 @@ class Image(SupportedType):
         msg.data = output.flatten()
         return msg
 
+    @classmethod
+    def to_shm_payload(cls, msg: ROSImage) -> Optional[Tuple[Dict, memoryview]]:
+        """Hand out the raw pixel buffer zero-copy, plus the header + geometry
+        fields needed to rebuild the message."""
+        meta = {
+            "h": msg.height,
+            "w": msg.width,
+            "e": msg.encoding,
+            "b": int(msg.is_bigendian),
+            "st": msg.step,
+            "s": msg.header.stamp.sec,
+            "ns": msg.header.stamp.nanosec,
+            "f": msg.header.frame_id,
+        }
+        return meta, memoryview(msg.data)
+
+    @classmethod
+    def from_shm_payload(cls, meta: Dict, buffer: bytes) -> ROSImage:
+        msg = ROSImage()
+        msg.header.stamp.sec = meta["s"]
+        msg.header.stamp.nanosec = meta["ns"]
+        msg.header.frame_id = meta["f"]
+        msg.height = meta["h"]
+        msg.width = meta["w"]
+        msg.encoding = meta["e"]
+        msg.is_bigendian = bool(meta["b"])
+        msg.step = meta["st"]
+        msg.data = buffer
+        return msg
+
 
 class CompressedImage(Image):
     """CompressedImage format usually provided by camera vendors"""
@@ -480,6 +534,29 @@ class CompressedImage(Image):
         msg = ROSCompressedImage()
         msg.format = "png"
         msg.data = output.flatten()
+        return msg
+
+    @classmethod
+    def to_shm_payload(
+        cls, msg: ROSCompressedImage
+    ) -> Optional[Tuple[Dict, memoryview]]:
+        """CompressedImage carries only a format string plus the encoded blob."""
+        meta = {
+            "fmt": msg.format,
+            "s": msg.header.stamp.sec,
+            "ns": msg.header.stamp.nanosec,
+            "f": msg.header.frame_id,
+        }
+        return meta, memoryview(msg.data)
+
+    @classmethod
+    def from_shm_payload(cls, meta: Dict, buffer: bytes) -> ROSCompressedImage:
+        msg = ROSCompressedImage()
+        msg.header.stamp.sec = meta["s"]
+        msg.header.stamp.nanosec = meta["ns"]
+        msg.header.frame_id = meta["f"]
+        msg.format = meta["fmt"]
+        msg.data = buffer
         return msg
 
 
@@ -533,6 +610,42 @@ class PointCloud2(SupportedType):
     _ros_type = ROSPointCloud2
     callback = callbacks.PointCloudCallback
     _ui_rate_sampled = True  # dense sensor stream
+
+    @classmethod
+    def to_shm_payload(cls, msg: ROSPointCloud2) -> Optional[Tuple[Dict, memoryview]]:
+        """The packed point buffer plus the field layout and geometry."""
+        meta = {
+            "h": msg.height,
+            "w": msg.width,
+            "b": int(msg.is_bigendian),
+            "ps": msg.point_step,
+            "rs": msg.row_step,
+            "d": int(msg.is_dense),
+            "fl": [(f.name, f.offset, f.datatype, f.count) for f in msg.fields],
+            "s": msg.header.stamp.sec,
+            "ns": msg.header.stamp.nanosec,
+            "f": msg.header.frame_id,
+        }
+        return meta, memoryview(msg.data)
+
+    @classmethod
+    def from_shm_payload(cls, meta: Dict, buffer: bytes) -> ROSPointCloud2:
+        msg = ROSPointCloud2()
+        msg.header.stamp.sec = meta["s"]
+        msg.header.stamp.nanosec = meta["ns"]
+        msg.header.frame_id = meta["f"]
+        msg.height = meta["h"]
+        msg.width = meta["w"]
+        msg.is_bigendian = bool(meta["b"])
+        msg.point_step = meta["ps"]
+        msg.row_step = meta["rs"]
+        msg.is_dense = bool(meta["d"])
+        msg.fields = [
+            ROSPointField(name=n, offset=o, datatype=dt, count=c)
+            for (n, o, dt, c) in meta["fl"]
+        ]
+        msg.data = buffer
+        return msg
 
 
 class JointState(SupportedType):

--- a/ros_sugar/io/utils.py
+++ b/ros_sugar/io/utils.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Dict, Callable, Union, Any
+from typing import List, Optional, Tuple, Dict, Callable, Union, Any
 import re
 import sys
 import base64
@@ -100,6 +100,35 @@ def process_encoding(encoding: str) -> Tuple[np.dtype, int]:
     return encoding_map[encoding]
 
 
+def depth_image_metadata(
+    encoding: str, depth_scale: Optional[float] = None
+) -> Tuple[np.dtype, float]:
+    """
+    Returns (dtype, scale) for a depth image encoding, where scale converts
+    raw pixel values to meters.
+
+    Metadata only. Consumers take the raw image_pre_processing view and apply
+    the scale per-pixel on their side.
+
+    - 16UC1 / mono16: uint16 depth in millimeters -> scale 1e-3
+    - 32FC1: float32 depth in meters -> scale 1.0
+    - depth_scale overrides the encoding default, for cameras publishing
+      uint16 in non-millimeter units (e.g. some ToF sensors use 0.1mm)
+    """
+    depth_encoding_map = {
+        "16uc1": (np.dtype(np.uint16), 1e-3),
+        "mono16": (np.dtype(np.uint16), 1e-3),
+        "32fc1": (np.dtype(np.float32), 1.0),
+    }
+    key = encoding.lower()
+    if key not in depth_encoding_map:
+        raise ValueError(f"Unsupported depth image encoding: {encoding}")
+    dtype, scale = depth_encoding_map[key]
+    if depth_scale is not None:
+        scale = float(depth_scale)
+    return dtype, scale
+
+
 def image_pre_processing(img, dtype, num_channels) -> np.ndarray:
     """
     Pre-processes ROS sensor_msgs/Image into a numpy array.
@@ -114,7 +143,8 @@ def image_pre_processing(img, dtype, num_channels) -> np.ndarray:
         np_arr.dtype.byteorder == "<"
         or (np_arr.dtype.byteorder == "=" and sys.byteorder == "little")
     ):
-        np_arr = np_arr.byteswap().newbyteorder()
+        # go through the dtype instead for np>=2 compat
+        np_arr = np_arr.byteswap().view(np_arr.dtype.newbyteorder())
 
     # Reshape
     if num_channels == 1:
@@ -609,7 +639,15 @@ def run_external_processor(
 # JSON-shaped dicts. Conversion goes by the DECLARED field type (not the default
 # value's Python type).
 _ROS_INT_TYPES = frozenset({
-    "int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "uint64", "char",
+    "int8",
+    "uint8",
+    "int16",
+    "uint16",
+    "int32",
+    "uint32",
+    "int64",
+    "uint64",
+    "char",
 })
 _ROS_FLOAT_TYPES = frozenset({"float", "double", "float32", "float64"})
 
@@ -621,7 +659,7 @@ def _split_ros_field_type(ros_type: str) -> Tuple[str, bool]:
     and plain scalars.
     """
     if ros_type.startswith("sequence<"):
-        inner = ros_type[len("sequence<"):].rstrip(">")
+        inner = ros_type[len("sequence<") :].rstrip(">")
         return inner.split(",")[0].strip(), True
     if "[" in ros_type:
         return ros_type.split("[")[0], True

--- a/ros_sugar/io/utils.py
+++ b/ros_sugar/io/utils.py
@@ -33,73 +33,73 @@ def convert_img_to_jpeg_str(img, node_name: str = "util") -> str:
         return base64.b64encode(buffer).decode("utf-8")
 
 
+# Image encodings to (dtype, channels), keyed lowercase
+IMAGE_ENCODINGS: Dict[str, Tuple[type, int]] = {
+    # RGB/BGR family
+    "rgb8": (np.uint8, 3),
+    "rgba8": (np.uint8, 4),
+    "rgb16": (np.uint16, 3),
+    "rgba16": (np.uint16, 4),
+    "bgr8": (np.uint8, 3),
+    "bgra8": (np.uint8, 4),
+    "bgr16": (np.uint16, 3),
+    "bgra16": (np.uint16, 4),
+    # Mono
+    "mono8": (np.uint8, 1),
+    "mono16": (np.uint16, 1),
+    # Bayer – typically raw single-channel
+    "bayer_rggb8": (np.uint8, 1),
+    "bayer_bggr8": (np.uint8, 1),
+    "bayer_gbrg8": (np.uint8, 1),
+    "bayer_grbg8": (np.uint8, 1),
+    "bayer_rggb16": (np.uint16, 1),
+    "bayer_bggr16": (np.uint16, 1),
+    "bayer_gbrg16": (np.uint16, 1),
+    "bayer_grbg16": (np.uint16, 1),
+    # CvMat types
+    "8uc1": (np.uint8, 1),
+    "8uc2": (np.uint8, 2),
+    "8uc3": (np.uint8, 3),
+    "8uc4": (np.uint8, 4),
+    "8sc1": (np.int8, 1),
+    "8sc2": (np.int8, 2),
+    "8sc3": (np.int8, 3),
+    "8sc4": (np.int8, 4),
+    "16uc1": (np.uint16, 1),
+    "16uc2": (np.uint16, 2),
+    "16uc3": (np.uint16, 3),
+    "16uc4": (np.uint16, 4),
+    "16sc1": (np.int16, 1),
+    "16sc2": (np.int16, 2),
+    "16sc3": (np.int16, 3),
+    "16sc4": (np.int16, 4),
+    "32sc1": (np.int32, 1),
+    "32sc2": (np.int32, 2),
+    "32sc3": (np.int32, 3),
+    "32sc4": (np.int32, 4),
+    "32fc1": (np.float32, 1),
+    "32fc2": (np.float32, 2),
+    "32fc3": (np.float32, 3),
+    "32fc4": (np.float32, 4),
+    "64fc1": (np.float64, 1),
+    "64fc2": (np.float64, 2),
+    "64fc3": (np.float64, 3),
+    "64fc4": (np.float64, 4),
+    "yuv422": (np.uint8, 2),
+}
+
+
 def process_encoding(encoding: str) -> Tuple[np.dtype, int]:
     """
     Returns dtype and number of channels from encoding
     """
     encoding = encoding.lower()
-
-    # Define mapping from encoding to (dtype, channels)
-    encoding_map = {
-        # RGB/BGR family
-        "rgb8": (np.uint8, 3),
-        "rgba8": (np.uint8, 4),
-        "rgb16": (np.uint16, 3),
-        "rgba16": (np.uint16, 4),
-        "bgr8": (np.uint8, 3),
-        "bgra8": (np.uint8, 4),
-        "bgr16": (np.uint16, 3),
-        "bgra16": (np.uint16, 4),
-        # Mono
-        "mono8": (np.uint8, 1),
-        "mono16": (np.uint16, 1),
-        # Bayer – typically raw single-channel
-        "bayer_rggb8": (np.uint8, 1),
-        "bayer_bggr8": (np.uint8, 1),
-        "bayer_gbrg8": (np.uint8, 1),
-        "bayer_grbg8": (np.uint8, 1),
-        "bayer_rggb16": (np.uint16, 1),
-        "bayer_bggr16": (np.uint16, 1),
-        "bayer_gbrg16": (np.uint16, 1),
-        "bayer_grbg16": (np.uint16, 1),
-        # CvMat types
-        "8uc1": (np.uint8, 1),
-        "8uc2": (np.uint8, 2),
-        "8uc3": (np.uint8, 3),
-        "8uc4": (np.uint8, 4),
-        "8sc1": (np.int8, 1),
-        "8sc2": (np.int8, 2),
-        "8sc3": (np.int8, 3),
-        "8sc4": (np.int8, 4),
-        "16uc1": (np.uint16, 1),
-        "16uc2": (np.uint16, 2),
-        "16uc3": (np.uint16, 3),
-        "16uc4": (np.uint16, 4),
-        "16sc1": (np.int16, 1),
-        "16sc2": (np.int16, 2),
-        "16sc3": (np.int16, 3),
-        "16sc4": (np.int16, 4),
-        "32sc1": (np.int32, 1),
-        "32sc2": (np.int32, 2),
-        "32sc3": (np.int32, 3),
-        "32sc4": (np.int32, 4),
-        "32fc1": (np.float32, 1),
-        "32fc2": (np.float32, 2),
-        "32fc3": (np.float32, 3),
-        "32fc4": (np.float32, 4),
-        "64fc1": (np.float64, 1),
-        "64fc2": (np.float64, 2),
-        "64fc3": (np.float64, 3),
-        "64fc4": (np.float64, 4),
-        "yuv422": (np.uint8, 2),
-    }
-
-    if encoding not in encoding_map:
+    if encoding not in IMAGE_ENCODINGS:
         if "yuv422" in encoding:
-            return encoding_map["yuv422"]
+            return IMAGE_ENCODINGS["yuv422"]
         raise ValueError(f"Unsupported encoding: {encoding}")
 
-    return encoding_map[encoding]
+    return IMAGE_ENCODINGS[encoding]
 
 
 def depth_image_metadata(
@@ -545,6 +545,37 @@ def _parse_array_type(arr: np.ndarray, ros_msg_cls: type) -> np.ndarray:
     elif ros_msg_cls == std_msg.Int64MultiArray:
         arr = arr.astype(np.int64)
     return arr
+
+
+def image_encoding(dtype: np.dtype, channels: int) -> str:
+    """The encoding an array of `dtype` with `channels` is published under.
+
+    The inverse of `process_encoding` is not unique. 8-bit color and grey follow
+    RGB convention. Everything else takes the CvMat form. A decoder producing
+    another layout has to name it itself.
+    """
+    dtype = np.dtype(dtype)
+    if dtype == np.uint8 and channels in (1, 3, 4):
+        return {1: "mono8", 3: "rgb8", 4: "rgba8"}[channels]
+    kind = {"u": "U", "i": "S", "f": "F"}.get(dtype.kind)
+    encoding = f"{dtype.itemsize * 8}{kind}C{channels}"
+    if kind is None or encoding.lower() not in IMAGE_ENCODINGS:
+        raise ValueError(
+            f"No image encoding is known for {dtype.name} with {channels} "
+            "channels; pass encoding="
+        )
+    return encoding
+
+
+def stamp_header(header, stamp: Optional[float], frame_id: str) -> None:
+    """Fill a header for a message built outside a publisher, which would
+    otherwise stamp it. Nothing is touched when neither value is given."""
+    if frame_id:
+        header.frame_id = frame_id
+    if stamp is not None:
+        seconds = int(stamp)
+        header.stamp.sec = seconds
+        header.stamp.nanosec = int((stamp - seconds) * 1e9)
 
 
 def bytes_to_array(buffer: Any, typecode: str = "B") -> array.array:

--- a/ros_sugar/io/utils.py
+++ b/ros_sugar/io/utils.py
@@ -521,7 +521,10 @@ def odom_from_frame1_to_frame2(
         _get_position_from_odom(pose_1_in_2),
         _get_orientation_from_odom(pose_1_in_2),
     )
-    return _get_odom_from_ndarray(transformed_pose)
+    transformed_odom = _get_odom_from_ndarray(transformed_pose)
+    transformed_odom.header = pose_target_in_1.header
+    transformed_odom.twist = pose_target_in_1.twist
+    return transformed_odom
 
 
 def _parse_array_type(arr: np.ndarray, ros_msg_cls: type) -> np.ndarray:

--- a/ros_sugar/io/utils.py
+++ b/ros_sugar/io/utils.py
@@ -2,6 +2,8 @@ from typing import List, Optional, Tuple, Dict, Callable, Union, Any
 import re
 import sys
 import base64
+import array
+
 import numpy as np
 import cv2
 from socket import socket
@@ -545,6 +547,17 @@ def _parse_array_type(arr: np.ndarray, ros_msg_cls: type) -> np.ndarray:
     return arr
 
 
+def bytes_to_array(buffer: Any, typecode: str = "B") -> array.array:
+    """A message sequence field built on the generated setter's fast path.
+
+    rosidl assigns an ``array.array`` of the field's typecode as is. Anything
+    else is walked element by element in Python.
+    """
+    data = array.array(typecode)
+    data.frombytes(buffer)
+    return data
+
+
 def numpy_to_multiarray(arr: np.ndarray, ros_msg_cls: type, labels=None):
     """
     Convert a numpy array to a ROS2 ___MultiArray message.
@@ -576,8 +589,9 @@ def numpy_to_multiarray(arr: np.ndarray, ros_msg_cls: type, labels=None):
         dim.stride = stride
         msg.layout.dim.append(dim)
 
-    # Flatten the array and convert to list for the message
-    msg.data = arr.flatten().tolist()
+    # make the generate setter take it without a per-element pass
+    typecode = msg.data.typecode
+    msg.data = bytes_to_array(arr.astype(np.dtype(typecode), copy=False).tobytes(), typecode)
 
     return msg
 

--- a/ros_sugar/launch/launch_actions.py
+++ b/ros_sugar/launch/launch_actions.py
@@ -74,6 +74,9 @@ class ComponentLaunchAction(NodeLaunchAction):
         :param event_name: Event key name to identify which events got triggered
         :type event_name: str
         """
+        # On shutdown, dont care about events queued here
+        if self.__context.is_shutdown:
+            return
         try:
             # Create a launch event of type InternalEvent with the event name
             event = InternalEvent(
@@ -179,7 +182,7 @@ class ComponentLaunchAction(NodeLaunchAction):
             raise Exception("Node executor is unknown")
         try:
             self.__ros_executor.add_node(self.__ros_node)
-            while self.__is_running:
+            while self.__is_running and not self.__context.is_shutdown:
                 # TODO: switch this to `spin()` when it considers
                 #   asynchronously added subscriptions.
                 self.__ros_executor.spin_once(

--- a/ros_sugar/launch/launcher.py
+++ b/ros_sugar/launch/launcher.py
@@ -1588,6 +1588,7 @@ class Launcher:
                 executable=executable_name,
                 output="screen",
                 arguments=arguments,
+                prefix=component.launch_prefix,
             )
         return NodeLaunchAction(
             package=pkg_name,
@@ -1597,6 +1598,7 @@ class Launcher:
             executable=executable_name,
             output="screen",
             arguments=arguments,
+            prefix=component.launch_prefix,
         )
 
     def _build_exit_handler_entity(
@@ -1720,6 +1722,14 @@ class Launcher:
         """
         Adds all components to be launched in separate threads
         """
+        if component.launch_prefix:
+            logger.warning(
+                f"Component '{component.node_name}' sets launch_prefix "
+                f"'{component.launch_prefix}', but runs multithreaded in a launcher "
+                "process with no process of its own, so the prefix has no effect. "
+                "Launch the component's package with multiprocessing=True to "
+                "apply it."
+            )
         component_action = ComponentLaunchAction(
             node=component,
             namespace=self._namespace,

--- a/ros_sugar/launch/launcher.py
+++ b/ros_sugar/launch/launcher.py
@@ -557,7 +557,8 @@ class Launcher:
 
         :param mount: Where this sensor sits, when nothing else publishes its
             frame into TF. Omit it if a URDF, a ``robot_state_publisher`` or
-            the sensor's own driver already does.
+            the sensor's own driver already does. A robot plugin's own
+            sensor placements come from its ``mounts`` list instead.
         :type mount: Optional[Mount]
 
         :raises ValueError: If a second robot plugin is attached, or if the id
@@ -586,6 +587,15 @@ class Launcher:
         if mount is not None:
             mount.child = plugin
             self._mounts.append(mount)
+        # A robot plugin may place its own built-in sensors (child = the frame
+        # those sensors' messages name); publish them like any other mount
+        for sensor_mount in getattr(plugin, "mounts", None) or []:
+            if sensor_mount.child is None:
+                raise ValueError(
+                    f"A mount declared by plugin '{plugin.metadata.name}' names no "
+                    "child frame: set 'child' to the frame the sensor publishes in."
+                )
+            self._mounts.append(sensor_mount)
 
     def _publish_mounts(self) -> None:
         """Hand every declared mount to the Monitor as a static transform to be published to /tf_static."""

--- a/ros_sugar/launch/launcher.py
+++ b/ros_sugar/launch/launcher.py
@@ -15,6 +15,7 @@ from typing import (
     Optional,
     Union,
     Any,
+    Set,
     Tuple,
     Mapping,
     cast,
@@ -67,6 +68,7 @@ from ..base_clients import ServiceClientConfig, ActionClientConfig
 from ..utils import InvalidAction, action_handler, has_decorator, SomeEntitiesType
 from ..ui_node import UINode, UINodeConfig
 from ..robot import (
+    AmbiguousPluginEntryError,
     FeedbackBus,
     Mount,
     InProcessFeedbackBus,
@@ -583,8 +585,7 @@ class Launcher:
             self._mounts.append(mount)
 
     def _publish_mounts(self) -> None:
-        """Hand every declared mount to the Monitor as a static transform to be published to /tf_static.
-        """
+        """Hand every declared mount to the Monitor as a static transform to be published to /tf_static."""
         if not self._mounts:
             return
         from geometry_msgs.msg import TransformStamped
@@ -649,6 +650,97 @@ class Launcher:
                         "attached to this recipe. Attached plugins: "
                         f"{', '.join(self._plugins) or 'none'}."
                     )
+
+    def _plugin_for_topic(self, topic) -> Optional[Plugin]:
+        """Resolve which attached plugin serves a topic, or ``None``.
+
+        ``use_plugin=True`` means the robot plugin; a string names a plugin by
+        its id. Mirrors the component-side resolution of the same name, minus
+        the logging — `_validate_plugin_references` has already rejected the
+        cases worth complaining about by the time this runs.
+        """
+        if not topic.use_plugin:
+            return None
+        if topic.use_plugin is True:
+            return self._robot_plugin
+        return self._plugins.get(topic.use_plugin)
+
+    def _resolve_plugin_demand(self) -> None:
+        """Tell each plugin which of its entries the recipe actually uses. Knowing what was asked for lets a plugin provide exactly that; see `Plugin.required_processes`.
+
+        Runs before the plugin hosts open, so `Plugin.on_attached` and
+        `required_processes` both see a populated set.
+        """
+        if not self._plugins:
+            return
+        feedbacks: Dict[str, Set[str]] = {pid: set() for pid in self._plugins}
+        commands: Dict[str, Set[str]] = {pid: set() for pid in self._plugins}
+
+        for component in self._components:
+            for topics, resolver, target in (
+                (getattr(component, "in_topics", None), "resolve_feedback", feedbacks),
+                (getattr(component, "out_topics", None), "resolve_command", commands),
+            ):
+                for topic in topics or []:
+                    plugin = self._plugin_for_topic(topic)
+                    if plugin is None:
+                        continue
+                    try:
+                        entry = getattr(plugin, resolver)(
+                            topic.name, topic.msg_type.__name__
+                        )
+                    except (TypeError, AmbiguousPluginEntryError):
+                        # A mis-wired topic. The component logs it and falls
+                        # back to an ordinary ROS topic
+                        continue
+                    if entry is not None:
+                        target[plugin.id].add(entry.key)
+
+        for plugin_id, plugin in self._plugins.items():
+            plugin._set_requested(
+                frozenset(feedbacks[plugin_id]), frozenset(commands[plugin_id])
+            )
+            if requested := sorted(feedbacks[plugin_id] | commands[plugin_id]):
+                logger.debug(f"Plugin '{plugin_id}' serves: {', '.join(requested)}")
+
+    def _launch_plugin_processes(self, plugin: Plugin) -> None:
+        """Add launch actions for the external drivers a plugin declares.
+
+        Each `robot.process.ProcessSpec` becomes an ordinary
+        `add_ros_node` action, so a plugin's driver is supervised exactly like
+        one a recipe added by hand.
+
+        Nothing here is fatal. A driver that fails to declare, or whose
+        precondition raises, is logged and skipped: the feedback it serves may
+        well be optional to the recipe, and turning a degraded run into no run
+        at all is the worse outcome.
+        """
+        try:
+            specs = plugin.required_processes()
+        except Exception as e:
+            logger.error(
+                f"Plugin '{plugin.id}' failed to declare its required "
+                f"processes: {e}. No driver will be started for it."
+            )
+            return
+
+        for spec in specs or []:
+            try:
+                if spec.precondition is not None and not spec.precondition():
+                    logger.info(
+                        f"Plugin '{plugin.id}': not starting '{spec.label}' "
+                        "(precondition not met -- typically the driver is "
+                        "already running)"
+                    )
+                    continue
+                self.add_ros_node(**spec.launch_kwargs())
+            except Exception as e:
+                label = getattr(spec, "label", spec)
+                logger.error(
+                    f"Plugin '{plugin.id}': could not add driver '{label}': {e}"
+                )
+                continue
+            logger.info(f"Plugin '{plugin.id}': starting driver '{spec.label}'")
 
     def _distribute_plugins(self) -> None:
         """Hand every attached plugin to every component.
@@ -716,8 +808,7 @@ class Launcher:
             )
         else:
             logger.info(
-                f"Applying robot base frame '{base_frame}' from plugin "
-                f"'{plugin_name}'"
+                f"Applying robot base frame '{base_frame}' from plugin '{plugin_name}'"
             )
         for component in self._components:
             if hasattr(component.config, "frames"):
@@ -758,9 +849,7 @@ class Launcher:
     def _set_frame(self, attribute: str, frame: str) -> None:
         """Set one frame on every component that has a frames configuration."""
         if not isinstance(frame, str) or not frame:
-            raise ValueError(
-                f"Frame name must be a non-empty string, got {frame!r}"
-            )
+            raise ValueError(f"Frame name must be a non-empty string, got {frame!r}")
         for component in self._components:
             if hasattr(component.config, "frames"):
                 setattr(component.config.frames, attribute, frame)
@@ -1879,6 +1968,12 @@ class Launcher:
         """
         if not self._plugins:
             return
+
+        if self._plugin_hosts:
+            return
+        # Record what the recipe asked each plugin for before anything opens
+        self._resolve_plugin_demand()
+
         # A socket feedback bus is needed when any component runs as its own
         # process; otherwise an in-process bus avoids the socket round trip.
         use_socket_bus = bool(self._pkg_executable)
@@ -1889,6 +1984,8 @@ class Launcher:
         bus.start()
 
         for plugin in self._plugins.values():
+            # Drivers first
+            self._launch_plugin_processes(plugin)
             host = RobotPluginHost(
                 plugin,
                 node=self.monitor_node,
@@ -1900,8 +1997,7 @@ class Launcher:
             self._plugin_hosts.append(host)
             # Register every non-ROS feedback's synthetic topic with the Monitor
             # so events over it are tracked without a ROS subscription.
-            # ROS-topic feedbacks keep a normal ROS subscription (their
-            # as_topic() is the real robot topic), so they are NOT external.
+            # ROS-topic feedbacks keep a normal ROS subscription so they are NOT external.
             for feedback in plugin.feedbacks.values():
                 if not feedback.is_ros_topic:
                     self.monitor_node.register_external_topic(feedback.as_topic())

--- a/ros_sugar/launch/launcher.py
+++ b/ros_sugar/launch/launcher.py
@@ -74,6 +74,7 @@ from ..robot import (
     InProcessFeedbackBus,
     Plugin,
     PluginRole,
+    PluginShmManager,
     RobotPlugin,
     RobotPluginHost,
     SocketFeedbackBus,
@@ -186,6 +187,8 @@ class Launcher:
             self.add_plugin(robot_plugin)
         # Shared by every attached plugin host, so the launcher owns it
         self._plugin_bus: Optional[FeedbackBus] = None
+        # Shared-memory writer pool for large feedbacks on the socket bus
+        self._plugin_shm: Optional[PluginShmManager] = None
         # Tracks whether the recipe explicitly set robot config. If not config
         # is pulled from a plugin. In case both present, recipe wins.
         self._robot_explicitly_set: bool = False
@@ -1982,6 +1985,9 @@ class Launcher:
         # so it has to outlive any single host
         self._plugin_bus = bus
         bus.start()
+        # Shared-memory writer pool for large feedbacks. Only useful on the
+        # socket bus (multiprocess).
+        self._plugin_shm = PluginShmManager() if use_socket_bus else None
 
         for plugin in self._plugins.values():
             # Drivers first
@@ -1992,6 +1998,7 @@ class Launcher:
                 bus=bus,
                 monitor_feed=self.monitor_node.feed_external_topic,
                 owns_bus=False,
+                shm=self._plugin_shm,
             )
             host.open()
             self._plugin_hosts.append(host)
@@ -2097,6 +2104,10 @@ class Launcher:
         if self._plugin_bus is not None:
             self._plugin_bus.close()
             self._plugin_bus = None
+        # Unlink the shared-memory segments once the writers (hosts) are down.
+        if self._plugin_shm is not None:
+            self._plugin_shm.close()
+            self._plugin_shm = None
 
         if self._thread_pool:
             self._thread_pool.shutdown()

--- a/ros_sugar/robot/__init__.py
+++ b/ros_sugar/robot/__init__.py
@@ -12,6 +12,7 @@ from .bus import FeedbackBus, InProcessFeedbackBus, SocketFeedbackBus
 from .command import CommandSpec, RobotCommand
 from .feedback import Feedback, FeedbackSpec
 from .mount import Mount
+from .process import ProcessSpec
 from .plugin import (
     AmbiguousPluginEntryError,
     Plugin,
@@ -45,6 +46,7 @@ __all__ = [
     "RobotPluginHost",
     "PluginMetadata",
     "AmbiguousPluginEntryError",
+    "ProcessSpec",
     # descriptors
     "Feedback",
     "FeedbackSpec",

--- a/ros_sugar/robot/__init__.py
+++ b/ros_sugar/robot/__init__.py
@@ -12,6 +12,7 @@ from .bus import FeedbackBus, InProcessFeedbackBus, SocketFeedbackBus
 from .shm import PluginShmManager
 from .command import CommandSpec, RobotCommand
 from .feedback import Feedback, FeedbackSpec
+from .mapping import NativeMapping, VendorMapping
 from .mount import Mount
 from .process import ProcessSpec
 from .plugin import (
@@ -51,6 +52,8 @@ __all__ = [
     # descriptors
     "Feedback",
     "FeedbackSpec",
+    "NativeMapping",
+    "VendorMapping",
     "RobotCommand",
     "CommandSpec",
     # registries

--- a/ros_sugar/robot/__init__.py
+++ b/ros_sugar/robot/__init__.py
@@ -9,6 +9,7 @@ Authors subclass `RobotPlugin`; see ``docs/development/custom_robot_plugin.md``.
 """
 
 from .bus import FeedbackBus, InProcessFeedbackBus, SocketFeedbackBus
+from .shm import PluginShmManager
 from .command import CommandSpec, RobotCommand
 from .feedback import Feedback, FeedbackSpec
 from .mount import Mount
@@ -70,6 +71,7 @@ __all__ = [
     "FeedbackBus",
     "InProcessFeedbackBus",
     "SocketFeedbackBus",
+    "PluginShmManager",
     # types
     "create_supported_type",
 ]

--- a/ros_sugar/robot/bus.py
+++ b/ros_sugar/robot/bus.py
@@ -14,7 +14,7 @@ import socket
 import struct
 import threading
 from abc import ABC, abstractmethod
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from rclpy.logging import get_logger
 
@@ -60,11 +60,11 @@ class FeedbackBus(ABC):
         """Attach to an already-started bus from a component process."""
 
     @abstractmethod
-    def publish(self, channel: str, data: bytes) -> None:
+    def publish(self, channel: str, data: Any) -> None:
         """Publish ``data`` on ``channel`` to every subscriber."""
 
     @abstractmethod
-    def subscribe(self, channel: str, on_data: Callable[[bytes], None]) -> BusHandle:
+    def subscribe(self, channel: str, on_data: Callable[[Any], None]) -> BusHandle:
         """Register ``on_data`` to receive every payload published on ``channel``."""
 
     @abstractmethod
@@ -76,13 +76,27 @@ class FeedbackBus(ABC):
         """Socket name for socket buses; ``None`` for in-process buses."""
         return None
 
+    @property
+    def carries_objects(self) -> bool:
+        """Whether publish/subscribe move live Python objects in-process.
+
+        True lets callers hand the decoded message straight to subscribers and
+        skip (de)serialization; False means the bus carries bytes only.
+        """
+        return False
+
 
 class InProcessFeedbackBus(FeedbackBus):
     """Direct in-process fan-out — used for multithreaded launch."""
 
     def __init__(self) -> None:
-        self._subs: Dict[str, List[Callable[[bytes], None]]] = {}
+        self._subs: Dict[str, List[Callable[[Any], None]]] = {}
         self._lock = threading.Lock()
+
+    @property
+    def carries_objects(self) -> bool:
+        """In-process fan-out hands subscribers the live object, unserialized."""
+        return True
 
     def start(self) -> None:  # noqa: D102
         pass
@@ -90,7 +104,7 @@ class InProcessFeedbackBus(FeedbackBus):
     def connect(self) -> None:  # noqa: D102
         pass
 
-    def publish(self, channel: str, data: bytes) -> None:  # noqa: D102
+    def publish(self, channel: str, data: Any) -> None:  # noqa: D102
         with self._lock:
             handlers = list(self._subs.get(channel, ()))
         for handler in handlers:
@@ -101,7 +115,7 @@ class InProcessFeedbackBus(FeedbackBus):
                     f"In-process feedback handler for '{channel}' raised: {e}"
                 )
 
-    def subscribe(self, channel: str, on_data: Callable[[bytes], None]) -> BusHandle:  # noqa: D102
+    def subscribe(self, channel: str, on_data: Callable[[Any], None]) -> BusHandle:  # noqa: D102
         with self._lock:
             self._subs.setdefault(channel, []).append(on_data)
 

--- a/ros_sugar/robot/mapping.py
+++ b/ros_sugar/robot/mapping.py
@@ -18,11 +18,28 @@ A plugin that declares neither simply cannot be mapped, and the CLI says so.
 
 from __future__ import annotations
 
+import glob
+import os
 from typing import Any, Dict, List, Optional
 
 from attrs import define, field
 
 from ..config import BaseAttrs
+
+
+def _discover_grid(store: str, active_link: str, preferred: Optional[str]):
+    """Find the occupancy-grid YAML in a store's active map."""
+    if not store:
+        return None
+    active = os.path.join(store, active_link or "active")
+    if not os.path.isdir(active):
+        return None
+    if preferred:
+        named = os.path.join(active, preferred)
+        if os.path.isfile(named):
+            return named
+    found = sorted(glob.glob(os.path.join(active, "*.yaml")))
+    return found[0] if len(found) == 1 else None
 
 
 @define(kw_only=True)
@@ -33,10 +50,11 @@ class VendorMapping(BaseAttrs):
     substituted with the map name at call time.
 
     :param start: Begin a mapping session.
-    :param stop: End it and save. Expect to run this more than once -- some
-        vendor tools need repeating before the finishing step completes, so
-        the caller retries and then verifies the map directory appeared rather
-        than trusting one exit code.
+    :param stop: End the session and save. A clean exit code does not mean the
+        map was written -- what settles it is the map appearing in the store.
+    :param stop_retries: How many extra times to re-issue ``stop`` if the map
+        has not appeared. Only for vendors that document stop as safe to repeat
+        and sometimes needing it; the default of 0 issues it once.
     :param store: Directory holding every map on the robot.
     :param grid: Occupancy-grid YAML filename inside a map directory. The
         default is the ROS ``map_server`` convention, which is also what
@@ -61,6 +79,7 @@ class VendorMapping(BaseAttrs):
 
     start: List[str] = field()
     stop: List[str] = field()
+    stop_retries: int = field(default=0)
     store: str = field()
     grid: str = field(default="occ_grid.yaml")
     cloud: str = field(default="full_cloud.pcd")
@@ -71,6 +90,15 @@ class VendorMapping(BaseAttrs):
     requires_root: bool = field(default=True)
     host: str = field(default="local")
     area_limit_m: Optional[float] = field(default=None)
+
+    def active_grid_path(self) -> Optional[str]:
+        """Absolute path of the active map's occupancy-grid YAML, or ``None``.
+
+        ``grid`` is preferred when it names a file that exists, otherwise the
+        sole ``.yaml`` in the directory is taken; an ambiguous directory returns
+        ``None`` rather than guessing.
+        """
+        return _discover_grid(self.store, self.active_link, self.grid)
 
     @property
     def kind(self) -> str:
@@ -111,6 +139,19 @@ class NativeMapping(BaseAttrs):
     z_min: float = field(default=0.15)
     z_max: float = field(default=0.80)
     resolution: float = field(default=0.05)
+
+    # Default path for maps it built through native emos tools.
+    store: str = field(default="~/emos/maps")
+    # Name of the symlink marking the active map in that store.
+    active_link: str = field(default="active")
+
+    def active_grid_path(self) -> Optional[str]:
+        """Absolute path of the active map's occupancy-grid YAML, or ``None``.
+
+        Same contract as `VendorMapping.active_grid_path`, so a recipe can ask
+        either provider the same question.
+        """
+        return _discover_grid(os.path.expanduser(self.store), self.active_link, None)
 
     @property
     def kind(self) -> str:

--- a/ros_sugar/robot/mapping.py
+++ b/ros_sugar/robot/mapping.py
@@ -1,0 +1,127 @@
+"""Mapping capability descriptors.
+
+A robot plugin declares *how* maps of its environment get built.
+Mapping is a one-off, operator-driven activity that produces a file
+on disk, so it is driven from the EMOS CLI.
+
+A declaration is read through ``python -m ros_sugar.robot inspect``.
+
+Two kinds:
+
+- `VendorMapping` -- the robot ships its own SLAM, reached by running a vendor
+  tool. The plugin supplies the argv and where the results land.
+- `NativeMapping` -- EMOS maps the environment itself from the plugin's own
+  LiDAR and IMU feedbacks.
+
+A plugin that declares neither simply cannot be mapped, and the CLI says so.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from attrs import define, field
+
+from ..config import BaseAttrs
+
+
+@define(kw_only=True)
+class VendorMapping(BaseAttrs):
+    """Mapping performed by the robot's own software.
+
+    The commands are argv lists rather than shell strings. ``{name}`` is
+    substituted with the map name at call time.
+
+    :param start: Begin a mapping session.
+    :param stop: End it and save. Expect to run this more than once -- some
+        vendor tools need repeating before the finishing step completes, so
+        the caller retries and then verifies the map directory appeared rather
+        than trusting one exit code.
+    :param store: Directory holding every map on the robot.
+    :param grid: Occupancy-grid YAML filename inside a map directory. The
+        default is the ROS ``map_server`` convention, which is also what
+        Kompass's ``MapServer`` loads.
+    :param cloud: Point-cloud filename inside a map directory.
+    :param apply: Make a map the active one. ``None`` if the vendor offers no
+        such command.
+    :param after_apply: Run after ``apply`` -- typically restarting the
+        vendor's localization service, without which the switch silently does
+        not take effect.
+    :param export: Package the active map for copying off the robot.
+    :param active_link: Name of the symlink in ``store`` pointing at the
+        active map.
+    :param requires_root: Whether the commands need privilege escalation. When
+        true the dashboard cannot drive this provider -- its daemon has no
+        terminal for a password prompt -- and directs the operator to the CLI.
+    :param host: ``"local"`` when the commands run on the machine EMOS is
+        installed on, otherwise ``"ssh://user@host"``.
+    :param area_limit_m: Largest square area the vendor supports, in metres,
+        if documented. Advisory only; shown to the operator before they start.
+    """
+
+    start: List[str] = field()
+    stop: List[str] = field()
+    store: str = field()
+    grid: str = field(default="occ_grid.yaml")
+    cloud: str = field(default="full_cloud.pcd")
+    apply: Optional[List[str]] = field(default=None)
+    after_apply: Optional[List[str]] = field(default=None)
+    export: Optional[List[str]] = field(default=None)
+    active_link: str = field(default="active")
+    requires_root: bool = field(default=True)
+    host: str = field(default="local")
+    area_limit_m: Optional[float] = field(default=None)
+
+    @property
+    def kind(self) -> str:
+        """Discriminator for consumers reading a `describe` tree."""
+        return "vendor"
+
+    def spec(self) -> Dict[str, Any]:
+        """JSON-serializable introspection record, tagged with `kind`."""
+        record = self.asdict()
+        record["kind"] = self.kind
+        return record
+
+
+@define(kw_only=True)
+class NativeMapping(BaseAttrs):
+    """Mapping performed by EMOS from the plugin's own sensor feedbacks.
+
+    The inputs are named by **feedback key**, not by topic, so the plugin stays
+    the single source of truth for what the topic actually is and a topic
+    rename does not invalidate this declaration.
+
+    :param cloud: Feedback key of the LiDAR point cloud.
+    :param imu: Feedback key of an IMU mounted with the LiDAR, at a rate
+        suitable for LiDAR-inertial odometry -- typically the one inside the
+        LiDAR itself. A robot-state IMU arriving at 10 Hz over telemetry is
+        far too slow. ``None`` means no IMU is available, which limits EMOS to
+        a LiDAR-only backend and degrades the result on a robot whose gait
+        pitches the sensor.
+    :param z_min: Bottom of the height band kept when flattening the 3D map to
+        an occupancy grid, in metres above the base frame's ground plane.
+        Anything below is floor.
+    :param z_max: Top of that band. Anything above cannot obstruct the robot.
+    :param resolution: Grid cell size in metres.
+    """
+
+    cloud: str = field()
+    imu: Optional[str] = field(default=None)
+    z_min: float = field(default=0.15)
+    z_max: float = field(default=0.80)
+    resolution: float = field(default=0.05)
+
+    @property
+    def kind(self) -> str:
+        """Discriminator for consumers reading a `describe` tree."""
+        return "native"
+
+    def spec(self) -> Dict[str, Any]:
+        """JSON-serializable introspection record, tagged with `kind`."""
+        record = self.asdict()
+        record["kind"] = self.kind
+        return record
+
+
+__all__ = ["VendorMapping", "NativeMapping"]

--- a/ros_sugar/robot/mapping.py
+++ b/ros_sugar/robot/mapping.py
@@ -65,12 +65,27 @@ class VendorMapping(BaseAttrs):
     :param after_apply: Run after ``apply`` -- typically restarting the
         vendor's localization service, without which the switch silently does
         not take effect.
-    :param export: Package the active map for copying off the robot.
+    :param export: Package a map for copying off the robot. Vendors commonly
+        only package the *active* map and take no argument, so ``{name}`` is
+        optional here.
+    :param export_dir: Where ``export`` leaves the archive, when the vendor
+        chooses the path itself. Empty means unknown, and the caller reports
+        only that the command ran.
+    :param import_: Unpack an archive produced by ``export`` into the store.
+        ``{path}`` is substituted with the archive's absolute path. Trailing
+        underscore because ``import`` is a keyword; it is ``import`` in `spec`.
+    :param remove: Delete a map. ``None`` where the vendor offers no such
+        command, in which case the map directory is removed directly.
     :param active_link: Name of the symlink in ``store`` pointing at the
         active map.
-    :param requires_root: Whether the commands need privilege escalation. When
-        true the dashboard cannot drive this provider -- its daemon has no
-        terminal for a password prompt -- and directs the operator to the CLI.
+    :param requires_root: Whether any command here escalates privilege. Purely
+        a capability hint: the dashboard cannot drive such a provider, because
+        its daemon has no terminal for a password prompt, so it directs the
+        operator to the CLI instead. It does *not* shape the commands --
+        escalation belongs in the argv, because it is per-verb. DEEP Robotics,
+        for instance, documents ``sudo`` on ``mapping`` and ``apply`` but not
+        on ``pack``, and prefixing it anyway would leave a root-owned archive
+        the operator cannot delete.
     :param host: ``"local"`` when the commands run on the machine EMOS is
         installed on, otherwise ``"ssh://user@host"``.
     :param area_limit_m: Largest square area the vendor supports, in metres,
@@ -86,6 +101,9 @@ class VendorMapping(BaseAttrs):
     apply: Optional[List[str]] = field(default=None)
     after_apply: Optional[List[str]] = field(default=None)
     export: Optional[List[str]] = field(default=None)
+    export_dir: str = field(default="")
+    import_: Optional[List[str]] = field(default=None)
+    remove: Optional[List[str]] = field(default=None)
     active_link: str = field(default="active")
     requires_root: bool = field(default=True)
     host: str = field(default="local")
@@ -108,6 +126,7 @@ class VendorMapping(BaseAttrs):
     def spec(self) -> Dict[str, Any]:
         """JSON-serializable introspection record, tagged with `kind`."""
         record = self.asdict()
+        record["import"] = record.pop("import_")
         record["kind"] = self.kind
         return record
 

--- a/ros_sugar/robot/plugin.py
+++ b/ros_sugar/robot/plugin.py
@@ -29,6 +29,7 @@ from ..config import BaseAttrs, RobotConfig, StrEnum
 from .bus import LOGGER_NAME, BusHandle, FeedbackBus, SocketFeedbackBus
 from .command import CommandSpec, RobotCommand
 from .feedback import Feedback, FeedbackSpec
+from .mount import Mount
 from .process import ProcessSpec
 from .registries import ActionRegistry, ActionSpec, EventRegistry, EventSpec
 from .shm import PluginShmManager, ShmDescriptor, ShmReaderCache
@@ -638,6 +639,11 @@ class RobotPlugin(Plugin):
         # is deliberately absent: where the robot has been placed is described
         # by the environment, not by the robot.
         self.base_frame: Optional[str] = None
+        # Static placements of the robot's own sensors relative to the body
+        # (child = the frame the sensor's messages name). The launcher
+        # publishes them as static transforms, so consumers can resolve where
+        # a built-in sensor sits without a URDF.
+        self.mounts: List[Mount] = []
 
 
 class SensorPlugin(Plugin):

--- a/ros_sugar/robot/plugin.py
+++ b/ros_sugar/robot/plugin.py
@@ -18,7 +18,7 @@ import inspect
 import json
 import re
 import threading
-from typing import Any, Callable, Dict, FrozenSet, List, Optional
+from typing import Any, Callable, Dict, FrozenSet, List, Optional, Union
 
 import msgpack
 from attrs import define, field
@@ -29,6 +29,7 @@ from ..config import BaseAttrs, RobotConfig, StrEnum
 from .bus import LOGGER_NAME, BusHandle, FeedbackBus, SocketFeedbackBus
 from .command import CommandSpec, RobotCommand
 from .feedback import Feedback, FeedbackSpec
+from .mapping import NativeMapping, VendorMapping
 from .mount import Mount
 from .process import ProcessSpec
 from .registries import ActionRegistry, ActionSpec, EventRegistry, EventSpec
@@ -609,6 +610,7 @@ class Plugin:
 
     def describe(self) -> Dict[str, Any]:
         """Return a JSON-serializable introspection tree for this plugin."""
+        mapping = getattr(self, "MAPPING", None)
         return {
             "metadata": self.metadata.asdict(),
             "transports": {name: t.kind for name, t in self.transports.items()},
@@ -616,6 +618,7 @@ class Plugin:
             "commands": [s.asdict() for s in self.list_commands()],
             "actions": [s.asdict() for s in self.list_actions()],
             "events": [s.asdict() for s in self.list_events()],
+            "mapping": mapping.spec() if mapping is not None else None,
             "role": str(self.role),
         }
 
@@ -630,6 +633,11 @@ class RobotPlugin(Plugin):
     """
 
     _role: PluginRole = PluginRole.ROBOT
+
+    # How this robot's environment gets mapped. A `VendorMapping` when the
+    # robot ships its own SLAM, a `NativeMapping` when EMOS builds the map
+    # from this plugin's sensor feedbacks, or ``None`` when neither.
+    MAPPING: Optional[Union[VendorMapping, NativeMapping]] = None
 
     def _base_init(self, cls: type) -> None:
         super()._base_init(cls)

--- a/ros_sugar/robot/plugin.py
+++ b/ros_sugar/robot/plugin.py
@@ -18,7 +18,7 @@ import inspect
 import json
 import re
 import threading
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, FrozenSet, List, Optional
 
 from attrs import define, field
 from rclpy.logging import get_logger
@@ -28,6 +28,7 @@ from ..config import BaseAttrs, RobotConfig, StrEnum
 from .bus import LOGGER_NAME, BusHandle, FeedbackBus, SocketFeedbackBus
 from .command import CommandSpec, RobotCommand
 from .feedback import Feedback, FeedbackSpec
+from .process import ProcessSpec
 from .registries import ActionRegistry, ActionSpec, EventRegistry, EventSpec
 from .transports import Transport
 from .transports.ros import RosServiceTransport, RosTopicTransport
@@ -184,6 +185,10 @@ class Plugin:
         # Explicit identity, if the recipe passed ``id=``; otherwise ``id``
         # derives from the metadata name (see the property below).
         self._id: str = ""
+        # What the recipe actually asked this plugin for. Populated by the
+        # launcher at bringup; empty everywhere else. See ``requested_feedbacks``.
+        self._requested_feedbacks: FrozenSet[str] = frozenset()
+        self._requested_commands: FrozenSet[str] = frozenset()
 
     # identity
     @property
@@ -305,6 +310,74 @@ class Plugin:
         `SocketFeedbackBus`.
         """
         self._bus = bus
+
+    # what the recipe asked for
+    @property
+    def requested_feedbacks(self) -> FrozenSet[str]:
+        """Keys of the feedbacks this recipe's components actually consume.
+
+        Populated by the launcher at bringup from every component's
+        ``Topic(use_plugin=...)`` reference, resolved through
+        `resolve_feedback`, and available before `on_attached` runs.
+
+        A plugin may expose far more than any one recipe uses. This is how a
+        plugin tells the difference — chiefly to avoid paying for what nobody
+        asked for, such as starting a LiDAR driver for a recipe that never
+        looks at the points. See `required_processes`.
+
+        Empty when no launcher populated it: a `RobotPluginHost` built directly,
+        as in tests and standalone tools, has no recipe to serve. Treat empty
+        as "nothing was asked for" rather than "everything" — a standalone host
+        that started every driver a plugin knows about would be a surprise.
+        """
+        return self._requested_feedbacks
+
+    @property
+    def requested_commands(self) -> FrozenSet[str]:
+        """Keys of the commands this recipe's components actually send.
+
+        The counterpart of `requested_feedbacks`, resolved from components'
+        output topics through `resolve_command`.
+        """
+        return self._requested_commands
+
+    def _set_requested(
+        self, feedbacks: FrozenSet[str], commands: FrozenSet[str]
+    ) -> None:
+        """Record what the recipe asked for. Called by the launcher only."""
+        self._requested_feedbacks = frozenset(feedbacks)
+        self._requested_commands = frozenset(commands)
+
+    # external processes
+    def required_processes(self) -> List[ProcessSpec]:
+        """External driver nodes this plugin needs running — override in
+        subclasses that front hardware served by a separate node.
+
+        Called once per bringup in the launcher process, after
+        `requested_feedbacks` and `requested_commands` are populated and before
+        `on_attached`. Return declarations only; the launcher starts and owns
+        the processes, so they get respawn, captured output and teardown
+        ordered with the recipe.
+
+        Gate on what was actually requested, so a recipe that ignores a sensor
+        does not pay to run its driver::
+
+            def required_processes(self):
+                if not {"lidar_front", "lidar_back"} & self.requested_feedbacks:
+                    return []
+                return [ProcessSpec(package="rslidar_sdk",
+                                    executable="rslidar_sdk_node",
+                                    parameters=[self.lidar_config],
+                                    precondition=self._lidar_port_is_free)]
+
+        Anything raised here is logged and skipped: a driver that cannot be
+        declared should not take the whole recipe down with it.
+
+        :return: Processes to launch, or ``[]`` (the default) for a plugin that
+            needs none.
+        """
+        # No processes by default -- see the docstring.
+        return []
 
     # host-side customization hook
     def on_attached(self, node: Any, bus: FeedbackBus) -> None:

--- a/ros_sugar/robot/plugin.py
+++ b/ros_sugar/robot/plugin.py
@@ -146,9 +146,7 @@ class Plugin:
                 # place for anything else lets the wrapped __init__ raise
                 # Python's own unexpected-keyword TypeError
                 explicit_frame = (
-                    kw.pop("frame_id", None)
-                    if isinstance(self, SensorPlugin)
-                    else None
+                    kw.pop("frame_id", None) if isinstance(self, SensorPlugin) else None
                 )
                 try:
                     bound = sig.bind(self, *args, **kw)
@@ -500,15 +498,26 @@ class Plugin:
         self, feedback: Feedback, on_ros_msg: Callable[[Any], None]
     ) -> BusHandle:
         """Subscribe to a feedback stream; ``on_ros_msg`` is called with each
-        decoded ROS message. Used by components for non-ROS feedback."""
+        decoded ROS message. Used by components for non-ROS feedback.
+
+        On an in-process bus (multithreaded launch) the decoded message is
+        handed to ``on_ros_msg`` directly, with no serialization. Every
+        consumer and the Monitor then share the one live message instance, so
+        consumers must treat feedback messages as read-only and deep-copy
+        before mutating. On a socket bus the payload is deserialized per consumer.
+        """
         if self._bus is None:
             raise RuntimeError(
                 "RobotPlugin.subscribe_feedback() called before a bus was attached"
             )
         ros_type = feedback.msg_type.get_ros_type()
 
-        def _on_data(data: bytes) -> None:
-            on_ros_msg(deserialize_message(data, ros_type))
+        def _on_data(payload: Any) -> None:
+            if self._bus.carries_objects:
+                # no deserialization needed
+                on_ros_msg(payload)
+            else:
+                on_ros_msg(deserialize_message(payload, ros_type))
 
         return self._bus.subscribe(feedback.channel, _on_data)
 
@@ -767,7 +776,11 @@ class RobotPluginHost:
         if msg is None:
             return
         self._stamp_frame(feedback, msg)
-        self.bus.publish(feedback.channel, serialize_message(msg))
+        if self.bus.carries_objects:
+            # no serialization needed
+            self.bus.publish(feedback.channel, msg)
+        else:
+            self.bus.publish(feedback.channel, serialize_message(msg))
         if self.monitor_feed is not None:
             self.monitor_feed(feedback.channel, msg)
 

--- a/ros_sugar/robot/plugin.py
+++ b/ros_sugar/robot/plugin.py
@@ -20,6 +20,7 @@ import re
 import threading
 from typing import Any, Callable, Dict, FrozenSet, List, Optional
 
+import msgpack
 from attrs import define, field
 from rclpy.logging import get_logger
 from rclpy.serialization import deserialize_message, serialize_message
@@ -30,8 +31,34 @@ from .command import CommandSpec, RobotCommand
 from .feedback import Feedback, FeedbackSpec
 from .process import ProcessSpec
 from .registries import ActionRegistry, ActionSpec, EventRegistry, EventSpec
+from .shm import PluginShmManager, ShmDescriptor, ShmReaderCache
 from .transports import Transport
 from .transports.ros import RosServiceTransport, RosTopicTransport
+
+
+# A 1-byte prefix distinguishing a CDR-serialized message from a shared-memory
+# descriptor to determine the bus type. The tag lives inside the payload and is
+# added/stripped only here. (only used in multiprocessing)
+_FB_KIND_CDR = b"\x00"  # rest is serialize_message() output
+_FB_KIND_SHM = b"\x01"  # rest is msgpack {"d": ShmDescriptor.pack(), "m": meta}
+
+#: Only feedbacks whose payload is at least this large take the SHM fast path;
+#: below it CDR is used.
+SHM_MIN_BYTES = 32 * 1024
+
+
+def _decode_shm_feedback(feedback: Feedback, reader: ShmReaderCache, body: bytes):
+    """Rebuild a feedback message from a shared-memory envelope. Used in feedback
+    consumer components.
+
+    Returns ``None`` when the frame was overwritten before it could be read. The
+    caller is expected to skip as a dropped frame.
+    """
+    env = msgpack.unpackb(body, raw=False)
+    buffer = reader.read(ShmDescriptor.unpack(env["d"]))
+    if buffer is None:
+        return None
+    return feedback.msg_type.from_shm_payload(env["m"], buffer)
 
 
 class AmbiguousPluginEntryError(LookupError):
@@ -287,7 +314,7 @@ class Plugin:
         # host publishes on
         if plugin_id := spec.get("id"):
             plugin._set_id(plugin_id)
-        if frame_id := spec.get("frame_id"):
+        if isinstance(plugin, SensorPlugin) and (frame_id := spec.get("frame_id")):
             plugin._set_frame_id(frame_id)
         plugin._bind_identity()
         if bus_endpoint is not None:
@@ -504,22 +531,41 @@ class Plugin:
         handed to ``on_ros_msg`` directly, with no serialization. Every
         consumer and the Monitor then share the one live message instance, so
         consumers must treat feedback messages as read-only and deep-copy
-        before mutating. On a socket bus the payload is deserialized per consumer.
+        before mutating. On a socket bus the payload is read from shared memory
+        or deserialized, per consumer.
         """
         if self._bus is None:
             raise RuntimeError(
                 "RobotPlugin.subscribe_feedback() called before a bus was attached"
             )
         ros_type = feedback.msg_type.get_ros_type()
+        # One shared-memory reader per subscription (only used in multiprocessing)
+        reader: Optional[ShmReaderCache] = (
+            None if self._bus.carries_objects else ShmReaderCache()
+        )
 
         def _on_data(payload: Any) -> None:
-            if self._bus.carries_objects:
-                # no deserialization needed
+            if reader is None:
+                # In-process bus: payload is the live decoded message object.
                 on_ros_msg(payload)
+                return
+            if payload[:1] == _FB_KIND_SHM:
+                # Multiprocessing: payload is in shared memory
+                msg = _decode_shm_feedback(feedback, reader, payload[1:])
+                if msg is not None:  # None -> frame was missed; drop it
+                    on_ros_msg(msg)
             else:
-                on_ros_msg(deserialize_message(payload, ros_type))
+                # Multiprocessing: payload is CDR-serialized
+                on_ros_msg(deserialize_message(payload[1:], ros_type))
 
-        return self._bus.subscribe(feedback.channel, _on_data)
+        handle = self._bus.subscribe(feedback.channel, _on_data)
+
+        def _unsubscribe() -> None:
+            handle.unsubscribe()
+            if reader is not None:
+                reader.close()
+
+        return BusHandle(_unsubscribe)
 
     def open_command(self, command: RobotCommand) -> None:
         """Prepare a command transport for sending from a component process.
@@ -667,12 +713,16 @@ class RobotPluginHost:
         bus: FeedbackBus,
         monitor_feed: Optional[Callable[[str, Any], None]] = None,
         owns_bus: bool = True,
+        shm: Optional[PluginShmManager] = None,
     ) -> None:
         self.plugin = plugin
         self.node = node
         self.bus = bus
         self.monitor_feed = monitor_feed
         self._owns_bus = owns_bus
+        # Shared-memory writer pool for large feedbacks on the socket bus; the
+        # launcher owns it and injects it. None -> everything takes the CDR path.
+        self._shm = shm
         self._active = False
         self._keep_alive_threads: List[threading.Thread] = []
         self._keep_alive_stop: Optional[threading.Event] = None
@@ -777,12 +827,39 @@ class RobotPluginHost:
             return
         self._stamp_frame(feedback, msg)
         if self.bus.carries_objects:
-            # no serialization needed
+            # In-process bus: hand over the live object, no serialization.
             self.bus.publish(feedback.channel, msg)
         else:
-            self.bus.publish(feedback.channel, serialize_message(msg))
+            self.bus.publish(feedback.channel, self._encode_feedback(feedback, msg))
         if self.monitor_feed is not None:
             self.monitor_feed(feedback.channel, msg)
+
+    def _encode_feedback(self, feedback: Feedback, msg: Any) -> bytes:
+        """Encode a feedback for the socket bus, tagged with its payload kind.
+
+        Large, feedbacks (camera frames, point clouds) go through the shared-memory
+        ring. The frame is written to a slot and only a tiny descriptor goes through
+        the bus. Everything else and any SHM failure falls back to CDR. .
+        """
+        if self._shm is not None:
+            shm_payload = feedback.msg_type.to_shm_payload(msg)
+            if shm_payload is not None:
+                # if shared memory feedback is implemented in the type
+                meta, view = shm_payload
+                if view.nbytes >= SHM_MIN_BYTES:
+                    try:
+                        writer = self._shm.writer_for(self.plugin.id, feedback.key)
+                        desc = writer.write(view)
+                        return _FB_KIND_SHM + msgpack.packb(  # pyright: ignore[reportOperatorIssue]
+                            {"d": desc.pack(), "m": meta}, use_bin_type=True
+                        )
+                    except Exception as e:  # pragma: no cover - defensive
+                        get_logger(LOGGER_NAME).warning(
+                            f"SHM encode for feedback '{feedback.key}' failed; "
+                            f"using CDR: {e}"
+                        )
+        # else: return serialized feedback
+        return _FB_KIND_CDR + serialize_message(msg)
 
     def _stamp_frame(self, feedback: Feedback, msg: Any) -> None:
         """Stamp a decoded message with the frame its data is in.

--- a/ros_sugar/robot/process.py
+++ b/ros_sugar/robot/process.py
@@ -1,0 +1,86 @@
+"""``ProcessSpec`` — external driver processes a plugin needs running.
+
+Some plugins front hardware whose data arrives from a separate driver node: a
+LiDAR whose points come from a vendor SDK node, a depth camera with its own
+pipeline. Which driver that is, and how it must be configured, is exactly the
+robot-specific knowledge a plugin exists to absorb — a recipe author should not
+have to know it, and should not have to start it by hand.
+
+A plugin declares such a process from `robot.plugin.Plugin.required_processes`;
+the `Launcher` owns it and brings it up through the same machinery as
+`Launcher.add_ros_node`. Plugins stay declarative and start nothing themselves,
+and the driver inherits launch's supervision: respawn, captured output, and
+teardown ordered with the rest of the recipe. A plugin that spawned its own
+subprocess would get none of that, and would leak a process still holding the
+device if the launcher were killed.
+"""
+
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from attrs import define, field
+
+from ..config import BaseAttrs
+
+
+@define(kw_only=True)
+class ProcessSpec(BaseAttrs):
+    """One external ROS node a plugin needs running.
+
+    The fields mirror the arguments of `Launcher.add_ros_node`, which is what
+    the launcher passes this to.
+
+    :param package: ROS package holding the executable.
+    :param executable: Executable name.
+    :param name: Node name; defaults to the executable's own.
+    :param parameters: Node parameters — dicts and/or paths to YAML files.
+    :param remappings: ``(from, to)`` topic/service remapping pairs.
+    :param arguments: Extra command-line arguments.
+    :param output: launch output configuration.
+    :param respawn: Restart the node if it exits. Defaults to ``True``: a
+        driver dying mid-run is the case this exists to survive.
+    :param respawn_delay: Seconds to wait before respawning.
+    :param precondition: Optional predicate, evaluated in the launcher process
+        immediately before the node is added. Return ``False`` to skip it.
+
+        Not a refinement — for a large class of drivers this is the difference
+        between working and not. A driver that binds a fixed port (most
+        LiDARs) cannot coexist with a second copy of itself, and many robots
+        already run the vendor's own instance from boot. Starting a second one
+        gives a node that comes up cleanly and then never publishes, which
+        reads as a crash and sends people looking in the wrong place. Detect
+        the running instance here and return ``False``.
+    """
+
+    package: str = field()
+    executable: str = field()
+    name: Optional[str] = field(default=None)
+    parameters: Optional[List[Any]] = field(default=None)
+    remappings: Optional[List[Tuple[str, str]]] = field(default=None)
+    arguments: Optional[List[str]] = field(default=None)
+    output: str = field(default="screen")
+    respawn: bool = field(default=True)
+    respawn_delay: float = field(default=2.0)
+    precondition: Optional[Callable[[], bool]] = field(default=None)
+
+    @property
+    def label(self) -> str:
+        """Human-readable identifier for logs."""
+        return self.name or f"{self.package}/{self.executable}"
+
+    def launch_kwargs(self) -> Dict[str, Any]:
+        """This spec as keyword arguments for `Launcher.add_ros_node`.
+
+        ``precondition`` is deliberately absent: it is the launcher's business,
+        not the launch system's.
+        """
+        return {
+            "package": self.package,
+            "executable": self.executable,
+            "name": self.name,
+            "parameters": self.parameters,
+            "remappings": self.remappings,
+            "arguments": self.arguments,
+            "output": self.output,
+            "respawn": self.respawn,
+            "respawn_delay": self.respawn_delay,
+        }

--- a/ros_sugar/robot/shm.py
+++ b/ros_sugar/robot/shm.py
@@ -1,0 +1,404 @@
+"""Shared-memory ring buffer for large robot-plugin feedback payloads.
+
+When a plugin feedback (a camera frame, a large custom struct) has to cross the process
+boundary between the plugin HOST and a component under multiprocess launch,
+this module carries the raw payload through POSIX shared memory instead. The
+HOST writes the frame into a slot of a per-channel ring buffer and publishes
+only a tiny descriptor (segment name, slot, sequence, length) over the existing
+bus socket. The consumer maps the segment and copies the frame out of the slot.
+The big buffer never gets CDR-encoded and never streams through the socket.
+
+Design Elements:
+
+* Single writer, many readers, per feedback channel. One `ShmRingWriter`
+  owns each segment and is the sole party that ever ``unlink``s it; readers only
+  attach and ``close``.
+* **Torn-read safety** is a per-slot seqlock (a ``state`` counter bumped to odd
+  before a write and to even after) combined with a ring depth of a few slots and
+  a reader that copies the slot out immediately. A reader that loses the race
+  gets ``None`` (a dropped frame). It never gets corrupt bytes or a stall.
+"""
+
+import os
+import re
+import struct
+from multiprocessing import resource_tracker, shared_memory
+from typing import Dict, List, Optional
+
+import msgpack
+from attrs import define, field
+
+try:
+    from _posixshmem import shm_unlink as _shm_unlink  # POSIX low-level shm removal
+except ImportError:  # pragma: no cover - non-POSIX
+    _shm_unlink = None
+
+# --- segment layout ---------------------------------------------------------
+#
+# [ control header | slot table (N entries) | data region (N slots) ]
+#
+# Header (packed little-endian, padded out to HEADER_SIZE):
+#   magic(4s) version(H) flags(H) slot_count(I) slot_size(I)
+#   epoch(I) data_off(I) write_seq(Q)
+# Slot-table entry (SLOT_ENTRY_SIZE each):
+#   state(Q, seqlock) frame_seq(Q) length(I) pad(4x)
+MAGIC = b"EMOS"  # 4-byte segment signature; checked on attach
+VERSION = 1
+
+_HEADER_FMT = "<4sHHIIIIQ"
+HEADER_SIZE = 64  # struct is 32 bytes; padded to a cache line
+_WRITE_SEQ_OFF = 24  # offset of write_seq within the header
+
+_SLOT_ENTRY_FMT = "<QQI4x"
+SLOT_ENTRY_SIZE = struct.calcsize(_SLOT_ENTRY_FMT)  # 24
+_STATE_OFF = 0  # within a slot entry
+_FRAME_SEQ_OFF = 8
+
+PAGE = 4096
+DEFAULT_SLOT_COUNT = (
+    4  # tradeoff between ring depth vs memory footprint (overwriteable)
+)
+DEFAULT_MIN_SLOT_SIZE = PAGE
+_READ_RETRIES = 4
+
+
+def _align(n: int, a: int) -> int:
+    return (n + a - 1) // a * a
+
+
+def _short(value: object, limit: int = 40) -> str:
+    """Sanitize an id fragment for use in a shm segment name (``[A-Za-z0-9_]``)."""
+    cleaned = re.sub(r"[^A-Za-z0-9]+", "_", str(value)).strip("_")
+    return cleaned[:limit] or "x"
+
+
+def segment_name_base(launcher_pid: int, plugin_id: str, feedback_key: str) -> str:
+    """Base name for a channel's segments; the epoch is appended per allocation.
+
+    Namespaced by launcher pid and plugin id + feedback key (unique per channel).
+    The final name stays well under ``NAME_MAX`` for ``/dev/shm`` entries.
+    """
+    return f"sc_{int(launcher_pid)}_{_short(plugin_id)}_{_short(feedback_key)}"
+
+
+def _open_segment(name: str, create: bool, size: int = 0) -> shared_memory.SharedMemory:
+    """Create/attach a ``SharedMemory`` under fully manual lifetime management.
+
+    The multiprocessing resource_tracker (bpo-38119) registers every segment a
+    process opens — a *reader* that only attaches included — and unlinks them at
+    interpreter exit. Left alone that would delete a writer's live segment out
+    from under it and print a "leaked shared_memory" warning per reader. We opt
+    the segment out of the tracker for **both** roles and take ownership ourselves.
+    Readers only ``close`` (munmap), and the writer removes the name with `_destroy`.
+
+    The trade is no tracker safety-net if the writer is hard-killed before
+    ``close()`` resulting in a bounded, pid+epoch-named leak.
+    """
+    try:
+        # for python3.13+
+        return shared_memory.SharedMemory(
+            name=name, create=create, size=size, track=False
+        )
+    except TypeError:
+        # for python3.8-3.12
+        shm = shared_memory.SharedMemory(name=name, create=create, size=size)
+        try:
+            resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore[attr-defined]
+        except Exception:
+            pass
+        return shm
+
+
+def _destroy(shm: shared_memory.SharedMemory) -> None:
+    """Unmap and remove a segment we own, bypassing the resource_tracker.
+
+    Unlink the name with the low-level ``shm_unlink`` rather than
+    ``SharedMemory.unlink``. Falls back to ``SharedMemory.unlink`` off POSIX.
+    """
+    try:
+        shm.close()
+    except Exception:
+        pass
+    try:
+        if _shm_unlink is not None:
+            _shm_unlink(shm._name)  # type: ignore[attr-defined]
+        else:  # pragma: no cover - non-POSIX fallback
+            shm.unlink()
+    except FileNotFoundError:
+        pass
+    except Exception:
+        pass
+
+
+@define(frozen=True)
+class ShmDescriptor:
+    """Everything a reader needs to locate one frame in shared memory."""
+
+    name: str = field()
+    slot: int = field()
+    seq: int = field()
+    length: int = field()
+    slot_count: int = field()
+
+    def pack(self) -> bytes:
+        """Serialize to a compact msgpack blob for the bus."""
+        return msgpack.packb(  # pyright: ignore[reportReturnType]
+            {
+                "n": self.name,
+                "sl": self.slot,
+                "sq": self.seq,
+                "ln": self.length,
+                "N": self.slot_count,
+            },
+            use_bin_type=True,
+        )
+
+    @classmethod
+    def unpack(cls, data: bytes) -> "ShmDescriptor":
+        d = msgpack.unpackb(data, raw=False)
+        return cls(
+            name=d["n"], slot=d["sl"], seq=d["sq"], length=d["ln"], slot_count=d["N"]
+        )
+
+
+class ShmRingWriter:
+    """The HOST side of one channel's ring. Writes frames and hands back descriptors.
+
+    Single-writer (each feedback channel is dispatched from one thread).
+    The segment is created lazily on the first ``write``, sized from the first
+    frame and recreated if any subsequent frame outgrows the slow (should be rare).
+    """
+
+    def __init__(
+        self,
+        name_base: str,
+        slot_count: int = DEFAULT_SLOT_COUNT,
+        min_slot_size: int = DEFAULT_MIN_SLOT_SIZE,
+    ) -> None:
+        if slot_count < 2:
+            raise ValueError("slot_count must be >= 2 for torn-read margin")
+        self._base = name_base
+        self._slot_count = slot_count
+        self._min_slot_size = min_slot_size
+        self._epoch = 0
+        self._write_seq = 0
+        self._slot_size = 0
+        self._data_off = 0
+        self._name = ""
+        self._shm: Optional[shared_memory.SharedMemory] = None
+
+        # Segments outgrown by a resize are kept mapped (and named) so any reader
+        # still holding an old descriptor can finish, unlinked at close().
+        self._retired: List[shared_memory.SharedMemory] = []
+
+    def _create_segment(self, slot_size: int) -> None:
+        name = f"{self._base}_{self._epoch}"
+        # align header size to cache line
+        data_off = _align(HEADER_SIZE + self._slot_count * SLOT_ENTRY_SIZE, HEADER_SIZE)
+        size = data_off + self._slot_count * slot_size
+        # create shared memory segment
+        try:
+            shm = _open_segment(name, create=True, size=size)
+        except FileExistsError:
+            # stale segment from a hard-killed prior run at this pid+epoch.
+            _destroy(_open_segment(name, create=False))
+            shm = _open_segment(name, create=True, size=size)
+        struct.pack_into(
+            _HEADER_FMT,
+            shm.buf,
+            0,  # buf write position
+            MAGIC,
+            VERSION,
+            0,  # flags (unused, might use in a later version)
+            self._slot_count,
+            slot_size,
+            self._epoch,
+            data_off,
+            self._write_seq,
+        )
+        # Slot table is zero-initialized by the OS. state=0 (even), frame_seq=0.
+        self._shm = shm
+        self._name = name
+        self._slot_size = slot_size
+        self._data_off = data_off
+
+    def write(self, buffer) -> ShmDescriptor:
+        """Copy ``buffer`` into the next slot and return its descriptor."""
+        mv = memoryview(buffer)
+        if mv.format != "B" or mv.ndim != 1:
+            mv = mv.cast("B")
+        n = mv.nbytes
+
+        if self._shm is None:
+            self._create_segment(_align(max(n, self._min_slot_size), PAGE))
+        elif n > self._slot_size:
+            self._retired.append(self._shm)
+            self._epoch += 1
+            self._create_segment(_align(max(n, self._min_slot_size), PAGE))
+
+        assert self._shm is not None
+        buf = self._shm.buf
+        slot = self._write_seq % self._slot_count
+        entry = HEADER_SIZE + slot * SLOT_ENTRY_SIZE
+
+        # Seqlock write: state odd = write in progress, even = committed.
+        # NOTE: These are plain, non-atomic stores. The reader tolerates the absence
+        # of memory fences by copying out and re-checking in ShmReaderCache.read
+        # Thus this is best-effort rather than a hardware guarantee.
+        state = struct.unpack_from("<Q", buf, entry + _STATE_OFF)[0]  # read seqlock
+        struct.pack_into("<Q", buf, entry + _STATE_OFF, state + 1)  # begin (odd)
+        data_start = self._data_off + slot * self._slot_size  # this slot's data
+        buf[data_start : data_start + n] = mv  # copy the frame into the slot
+        # stamp this frame's seq + byte length
+        struct.pack_into("<QI", buf, entry + _FRAME_SEQ_OFF, self._write_seq, n)
+        struct.pack_into("<Q", buf, entry + _STATE_OFF, state + 2)  # commit (even)
+
+        # create the descriptor for readers
+        desc = ShmDescriptor(
+            name=self._name,
+            slot=slot,
+            seq=self._write_seq,
+            length=n,
+            slot_count=self._slot_count,
+        )
+        self._write_seq += 1
+        struct.pack_into("<Q", buf, _WRITE_SEQ_OFF, self._write_seq)
+        return desc
+
+    def close(self) -> None:
+        """Unmap and unlink the current and all retired segments. Idempotent."""
+        for shm in [self._shm, *self._retired]:
+            if shm is not None:
+                _destroy(shm)
+        self._shm = None
+        self._retired.clear()
+
+
+class ShmReaderCache:
+    """Consumer side. Attach segments by name (cached) and copy frames out."""
+
+    def __init__(self, retries: int = _READ_RETRIES) -> None:
+        self._retries = retries
+        # name -> (shm, slot_count, slot_size, data_off)
+        self._segs: Dict[str, tuple] = {}
+
+    def _attach(self, name: str) -> Optional[tuple]:
+        # if already gotten, return cached
+        info = self._segs.get(name)
+        if info is not None:
+            return info
+        try:
+            shm = _open_segment(name, create=False)
+        except FileNotFoundError:
+            return None  # unlinked before we attached -> drop
+        magic, _version, _flags, slot_count, slot_size, _epoch, data_off, _wseq = (
+            struct.unpack_from(_HEADER_FMT, shm.buf, 0)
+        )
+        # gate on magic
+        if magic != MAGIC:
+            shm.close()
+            return None
+        # cache and return
+        info = (shm, slot_count, slot_size, data_off)
+        self._segs[name] = info
+        return info
+
+    def read(self, desc: ShmDescriptor) -> Optional[bytes]:
+        """Return the frame ``desc`` points at, or ``None`` if it was missed.
+
+        ``None`` means the slot was recycled, the writer was mid-write across
+        every retry, or the segment is already gone. All such conditions are
+        considered dropped frames.
+        """
+        info = self._attach(desc.name)
+        if info is None:
+            return None
+        shm, _slot_count, slot_size, data_off = info
+        buf = shm.buf
+        entry = HEADER_SIZE + desc.slot * SLOT_ENTRY_SIZE
+        data_start = data_off + desc.slot * slot_size
+        end = data_start + desc.length
+
+        # Seqlock validation. Read state before and after copying and trust the
+        # frame only if it stayed even, unchanged, and still tagged with frame_seq
+        # across the whole copy.
+
+        # NOTE: This is best-effort. A sufficiently adversarial interleaving could
+        # pass the checks below over torn bytes. In practice the reader copies
+        # the slot out immediately, so for a tear to slip through, the writer would
+        # have to lap the entire ``slot_count``-deep ring mid-copy. Worst case is
+        # a single bad frame acceptable for a streaming sensor.
+        for _ in range(self._retries):
+            s0 = struct.unpack_from("<Q", buf, entry + _STATE_OFF)[0]
+            # check for even
+            if s0 & 1:
+                continue  # writer mid-write on this slot
+            # check for frame_seq
+            fs0 = struct.unpack_from("<Q", buf, entry + _FRAME_SEQ_OFF)[0]
+            if fs0 != desc.seq:
+                return None  # slot already holds a different frame (recycled)
+            # copy out
+            data = bytes(buf[data_start:end])
+            # check for still even and frame_seq to remain the same
+            s1 = struct.unpack_from("<Q", buf, entry + _STATE_OFF)[0]
+            fs1 = struct.unpack_from("<Q", buf, entry + _FRAME_SEQ_OFF)[0]
+            if s0 == s1 and fs1 == desc.seq:
+                return data
+        return None
+
+    def close(self) -> None:
+        """Unmap every attached segment. Idempotent."""
+        for info in self._segs.values():
+            try:
+                info[0].close()
+            except Exception:
+                pass
+        self._segs.clear()
+
+
+class PluginShmManager:
+    """Owns every channel's `ShmRingWriter` for one launch.
+
+    Created by the launcher alongside the socket feedback bus and injected into
+    each plugin HOST, which requests a per-channel writer via `writer_for`.
+    Closing the manager tears down every segment.
+    """
+
+    def __init__(
+        self,
+        launcher_pid: Optional[int] = None,
+        slot_count: int = DEFAULT_SLOT_COUNT,
+        min_slot_size: int = DEFAULT_MIN_SLOT_SIZE,
+    ) -> None:
+        self._pid = os.getpid() if launcher_pid is None else launcher_pid
+        self._slot_count = slot_count
+        self._min_slot_size = min_slot_size
+        self._writers: Dict[str, ShmRingWriter] = {}
+
+    def writer_for(self, plugin_id: str, feedback_key: str) -> ShmRingWriter:
+        """Create shm writer certain feedback out of certain plugin"""
+        key = f"{plugin_id}/{feedback_key}"
+        writer = self._writers.get(key)
+        if writer is None:
+            writer = ShmRingWriter(
+                segment_name_base(self._pid, plugin_id, feedback_key),
+                slot_count=self._slot_count,
+                min_slot_size=self._min_slot_size,
+            )
+            self._writers[key] = writer
+        return writer
+
+    def close(self) -> None:
+        """Close and unlink every channel's segments. Idempotent."""
+        for writer in self._writers.values():
+            writer.close()
+        self._writers.clear()
+
+
+__all__ = [
+    "ShmDescriptor",
+    "ShmRingWriter",
+    "ShmReaderCache",
+    "PluginShmManager",
+    "segment_name_base",
+]

--- a/test/external_launch_test.py
+++ b/test/external_launch_test.py
@@ -56,3 +56,59 @@ def test_include_launch_file_missing_in_package_raises(launcher):
         launcher.include_launch_file(
             package="automatika_ros_sugar", launch_file="no_such.launch.py"
         )
+
+
+# ---- component launch_prefix (issue #63) -----------------------------------
+
+
+def test_launch_prefix_reaches_the_component_process(launcher):
+    """A prefix set on the component must end up on its process description,
+    where ros2 launch prepends it to the command -- CPU pinning, priorities
+    and profilers all hang off this."""
+    from ros_sugar.core.component import BaseComponent
+
+    component = BaseComponent(component_name="pinned_component")
+    component.launch_prefix = "taskset -c 4-7"
+
+    action = launcher._build_component_launch_action(
+        component, "automatika_ros_sugar", "executable"
+    )
+
+    prefix = action.process_description.prefix
+    assert prefix is not None, "the prefix never reached the launch action"
+    assert "".join(sub.text for sub in prefix) == "taskset -c 4-7"
+
+
+def test_launch_prefix_defaults_to_no_prefix(launcher):
+    """Passing prefix=None is upstream's own default: the prefix resolves to
+    launch's global `launch-prefix` configuration, with no user text in it."""
+    from launch.substitutions import TextSubstitution
+
+    from ros_sugar.core.component import BaseComponent
+
+    component = BaseComponent(component_name="unpinned_component")
+    action = launcher._build_component_launch_action(
+        component, "automatika_ros_sugar", "executable"
+    )
+    prefix = action.process_description.prefix
+    assert not any(isinstance(sub, TextSubstitution) for sub in prefix)
+
+
+def test_launch_prefix_in_thread_mode_warns(launcher, caplog, monkeypatch):
+    """A component in a launcher thread has no process of its own, so a set
+    prefix cannot apply -- that must be said, not silently ignored."""
+    import logging
+
+    from ros_sugar.core.component import BaseComponent
+    from ros_sugar.launch import logger as launch_logger
+
+    component = BaseComponent(component_name="threaded_pinned_component")
+    component.launch_prefix = "taskset -c 4-7"
+
+    # the launch logger does not propagate to the root logger caplog listens on
+    monkeypatch.setattr(launch_logger, "propagate", True)
+    with caplog.at_level(logging.WARNING, logger=launch_logger.name):
+        launcher._setup_component_in_thread(component)
+
+    assert "launch_prefix" in caplog.text
+    assert "no effect" in caplog.text

--- a/test/io_types_test.py
+++ b/test/io_types_test.py
@@ -1403,7 +1403,7 @@ def test_pointcloud2_shm_payload_roundtrip():
     src.header.stamp.sec = 1
     src.header.stamp.nanosec = 2
     src.height, src.width = 1, 3
-    src.is_bigendian = 0
+    src.is_bigendian = False
     src.point_step = 12
     src.row_step = 36
     src.is_dense = True

--- a/test/io_types_test.py
+++ b/test/io_types_test.py
@@ -1544,3 +1544,115 @@ def test_multiarray_from_numpy_takes_the_fast_path():
     assert list(double.data) == values.flatten().tolist()
     assert np.allclose(list(single.data), values.flatten())
     assert [dim.size for dim in double.layout.dim] == [2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Building messages from arrays and intrinsics: complete, and the publisher's
+# header handling left alone
+# ---------------------------------------------------------------------------
+
+
+def test_image_from_numpy_is_complete_and_leaves_the_header_to_the_publisher():
+    from ros_sugar.io.supported_types import Image
+
+    frame = np.zeros((4, 6, 3), dtype=np.uint8)
+    msg = Image.convert(frame)
+    assert (msg.height, msg.width, msg.step) == (4, 6, 18)
+    assert msg.encoding == "rgb8" and msg.is_bigendian == 0
+    # the publisher stamps and frames after conversion; nothing pre-empts it
+    assert msg.header.frame_id == "" and msg.header.stamp.sec == 0
+
+
+@pytest.mark.parametrize(
+    "shape, dtype, expected, step",
+    [
+        ((4, 6), np.uint8, "mono8", 6),
+        ((4, 6, 4), np.uint8, "rgba8", 24),
+        ((4, 6), np.uint16, "16UC1", 12),
+        ((4, 6), np.float32, "32FC1", 24),
+    ],
+)
+def test_image_encoding_is_inferred_from_the_array(shape, dtype, expected, step):
+    from ros_sugar.io.supported_types import Image
+
+    msg = Image.convert(np.zeros(shape, dtype=dtype))
+    assert msg.encoding == expected and msg.step == step
+
+
+def test_image_encoding_stated_by_a_decoder_wins_and_decodes_back():
+    """A BGR decoder has to say so; the package's own callback then reads the
+    frame back with the right shape."""
+    from sensor_msgs.msg import Image as ROSImage
+
+    from ros_sugar.io.callbacks import ImageCallback
+    from ros_sugar.io.supported_types import Image
+
+    frame = np.zeros((4, 6, 3), dtype=np.uint8)
+    frame[1, 2] = (255, 0, 0)  # blue, as OpenCV lays it out
+    msg = Image.convert(frame, encoding="bgr8", stamp=1234.5, frame_id="front_optical")
+    assert isinstance(msg, ROSImage) and msg.encoding == "bgr8"
+    assert msg.header.frame_id == "front_optical"
+    assert msg.header.stamp.sec == 1234
+    assert msg.header.stamp.nanosec == pytest.approx(5e8, rel=1e-3)
+
+    reader = ImageCallback(Topic(name="/cam", msg_type="Image"))
+    reader.callback(msg)
+    decoded = reader.get_output()
+    assert decoded.shape == (4, 6, 3)
+    assert reader.frame_id == "front_optical"
+
+
+def test_image_from_an_unknown_layout_asks_for_the_encoding():
+    from ros_sugar.io.supported_types import Image
+
+    with pytest.raises(ValueError, match="encoding"):
+        Image.convert(np.zeros((4, 6), dtype=np.float16))
+    with pytest.raises(ValueError, match="\\(H, W\\)"):
+        Image.convert(np.zeros(24, dtype=np.uint8))
+
+
+def test_camera_info_from_raw_intrinsics_round_trips_through_the_reader():
+    from ros_sugar.io.supported_types import CameraInfo
+
+    raw = CameraIntrinsics(
+        fx=500.0, fy=510.0, cx=320.0, cy=240.0, width=640, height=480,
+        distortion_model="plumb_bob",
+        distortion=np.array([0.1, -0.2, 0.0, 0.0, 0.05]),
+        frame_id="front_optical", timestamp=12.25,
+    )
+    msg = CameraInfo.convert(raw)
+    # a raw image: K and D carry it, P stays unset so a reader falls back to K
+    assert list(msg.p) == [0.0] * 12
+    assert msg.k[0] == 500.0 and msg.k[4] == 510.0 and msg.k[2] == 320.0
+    assert list(msg.d) == pytest.approx([0.1, -0.2, 0.0, 0.0, 0.05])
+
+    back = read_camera_info(msg)
+    assert (back.fx, back.fy, back.cx, back.cy) == (500.0, 510.0, 320.0, 240.0)
+    assert (back.width, back.height) == (640, 480)
+    assert np.array_equal(back.distortion, raw.distortion)
+    assert back.distortion_model == "plumb_bob"
+    assert back.frame_id == "front_optical"
+    assert back.timestamp == pytest.approx(12.25)
+
+
+def test_camera_info_from_rectified_intrinsics_publishes_the_projection():
+    from ros_sugar.io.supported_types import CameraInfo
+
+    rectified = CameraIntrinsics(
+        fx=400.0, fy=400.0, cx=300.0, cy=200.0, width=640, height=480,
+        frame_id="front_optical",
+    )
+    msg = CameraInfo.convert(rectified, stamp=3.0)
+    assert msg.p[0] == 400.0 and msg.p[6] == 200.0
+    assert msg.header.stamp.sec == 3 and msg.header.frame_id == "front_optical"
+
+    back = read_camera_info(msg)
+    assert (back.fx, back.cx) == (400.0, 300.0)
+    assert back.distortion.size == 0
+
+
+def test_camera_info_message_passes_through():
+    from ros_sugar.io.supported_types import CameraInfo
+
+    info = _camera_info()
+    assert CameraInfo.convert(info) is info

--- a/test/io_types_test.py
+++ b/test/io_types_test.py
@@ -11,6 +11,7 @@ Sections, one per message type:
   extraction in world frame, UI content
 - MultiArray: layout-driven reshaping
 - Image: raw buffer decoding
+- Depth image metadata: encoding -> (dtype, scale), buffer untouched
 - CameraInfo: CameraInfoCallback -> CameraIntrinsics, rectification,
   binning and region of interest corrections
 - Path: UI downsampling
@@ -49,6 +50,7 @@ from ros_sugar.io.datatypes import (
     PointCloudData,
     read_camera_info,
 )
+from ros_sugar.io.utils import depth_image_metadata
 from ros_sugar.io import supported_types
 
 
@@ -921,6 +923,66 @@ def test_image_rgb8_decoding():
     np.testing.assert_array_equal(
         output, np.arange(12, dtype=np.uint8).reshape(2, 2, 3)
     )
+
+
+def test_image_big_endian_uint16_decoding():
+    """is_bigendian buffers must byte-swap on read (also guards the
+    numpy>=2-compatible newbyteorder path)."""
+    values = np.array([[1, 256], [4096, 65535]], dtype=np.uint16)
+    msg = Image()
+    msg.height = 2
+    msg.width = 2
+    msg.encoding = "mono16"
+    msg.step = 4
+    msg.is_bigendian = 1
+    msg.data = values.astype(">u2").tobytes()
+    output = _fed_callback(ImageCallback, "Image", msg).get_output()
+    np.testing.assert_array_equal(output, values)
+
+
+def test_depth_image_view_is_zero_copy():
+    """A 16UC1 depth image must come back as the raw uint16 buffer view:
+    same values, same memory, no normalization pass."""
+    values = np.array([[500, 1000], [1500, 65535]], dtype=np.uint16)
+    msg = Image()
+    msg.height = 2
+    msg.width = 2
+    msg.encoding = "16UC1"
+    msg.step = 4
+    msg.data = values.tobytes()
+    output = _fed_callback(ImageCallback, "Image", msg).get_output()
+    assert output.dtype == np.uint16
+    assert output.flags["C_CONTIGUOUS"]
+    np.testing.assert_array_equal(output, values)
+    assert np.shares_memory(output, np.frombuffer(msg.data, dtype=np.uint16))
+
+
+# ---------------------------------------------------------------------------
+# Depth image metadata
+# ---------------------------------------------------------------------------
+
+
+def test_depth_metadata_encoding_map():
+    assert depth_image_metadata("16UC1") == (np.dtype(np.uint16), 1e-3)
+    assert depth_image_metadata("mono16") == (np.dtype(np.uint16), 1e-3)
+    assert depth_image_metadata("32FC1") == (np.dtype(np.float32), 1.0)
+
+
+def test_depth_metadata_is_case_insensitive():
+    assert depth_image_metadata("16uc1") == depth_image_metadata("16UC1")
+    assert depth_image_metadata("Mono16") == depth_image_metadata("mono16")
+
+
+def test_depth_metadata_scale_override():
+    # e.g. a ToF camera publishing uint16 in 0.1mm units
+    dtype, scale = depth_image_metadata("16UC1", depth_scale=1e-4)
+    assert dtype == np.dtype(np.uint16)
+    assert scale == 1e-4
+
+
+def test_depth_metadata_rejects_non_depth_encodings():
+    with pytest.raises(ValueError, match="Unsupported depth image encoding"):
+        depth_image_metadata("rgb8")
 
 
 # ---------------------------------------------------------------------------

--- a/test/io_types_test.py
+++ b/test/io_types_test.py
@@ -263,6 +263,34 @@ def test_cloud_unfiltered_request_returns_the_raw_buffer():
     assert bytes(pc.data) == bytes(msg.data)
 
 
+def test_cloud_buffer_layout_is_the_raw_buffer_and_its_fields():
+    """buffer_layout() is the exact keyword set a raw-buffer consumer takes:
+    the buffer itself (no copy) and the fields needed to walk it, nothing
+    else from the container."""
+    output = _cloud_output(
+        _make_cloud(CLOUD_POINTS, point_padding=4, height=2, row_padding=8)
+    )
+    assert output is not None
+    layout = output.buffer_layout()
+    assert set(layout) == {
+        "data",
+        "point_step",
+        "row_step",
+        "height",
+        "width",
+        "x_offset",
+        "y_offset",
+        "z_offset",
+    }
+    assert layout["data"] is output.data
+    assert (layout["point_step"], layout["row_step"]) == (
+        output.point_step,
+        output.row_step,
+    )
+    assert (layout["height"], layout["width"]) == (2, 2)
+    assert (layout["x_offset"], layout["y_offset"], layout["z_offset"]) == (0, 4, 8)
+
+
 def test_cloud_z_band_filter():
     points = [(1.0, 0.0, -0.5), (1.0, 0.0, 0.1), (1.0, 0.0, 0.9), (1.0, 0.0, 5.0)]
     pc = _filtered(_make_cloud(points), min_z=0.0, max_z=1.0)
@@ -1326,3 +1354,82 @@ def test_camera_info_type_registration():
     assert _topic("CameraInfo").msg_type is supported_types.CameraInfo
     info = _camera_info()
     assert supported_types.CameraInfo.convert(info) is info
+
+
+# --- Shared-memory feedback fast-path hooks --------------------------------
+
+
+def test_image_shm_payload_roundtrip():
+    src = Image()
+    src.header.frame_id = "cam_optical"
+    src.header.stamp.sec = 12
+    src.header.stamp.nanosec = 345
+    src.height, src.width = 4, 6
+    src.encoding = "rgb8"
+    src.is_bigendian = 1
+    src.step = src.width * 3
+    src.data = bytes(range(src.height * src.step))
+
+    meta, view = supported_types.Image.to_shm_payload(src)
+    assert bytes(view) == bytes(src.data)  # zero-copy view of the pixel buffer
+
+    out = supported_types.Image.from_shm_payload(meta, bytes(view))
+    assert (out.height, out.width, out.encoding) == (4, 6, "rgb8")
+    assert (out.is_bigendian, out.step) == (1, 18)
+    assert out.header.frame_id == "cam_optical"
+    assert (out.header.stamp.sec, out.header.stamp.nanosec) == (12, 345)
+    assert bytes(out.data) == bytes(src.data)
+
+
+def test_compressed_image_shm_payload_roundtrip():
+    src = supported_types.CompressedImage.get_ros_type()()
+    src.header.frame_id = "cam"
+    src.header.stamp.sec = 7
+    src.header.stamp.nanosec = 8
+    src.format = "jpeg"
+    src.data = bytes([1, 2, 3, 4, 5])
+
+    meta, view = supported_types.CompressedImage.to_shm_payload(src)
+    out = supported_types.CompressedImage.from_shm_payload(meta, bytes(view))
+    assert out.format == "jpeg"
+    assert out.header.frame_id == "cam"
+    assert (out.header.stamp.sec, out.header.stamp.nanosec) == (7, 8)
+    assert bytes(out.data) == b"\x01\x02\x03\x04\x05"
+
+
+def test_pointcloud2_shm_payload_roundtrip():
+    src = PointCloud2()
+    src.header.frame_id = "lidar"
+    src.header.stamp.sec = 1
+    src.header.stamp.nanosec = 2
+    src.height, src.width = 1, 3
+    src.is_bigendian = 0
+    src.point_step = 12
+    src.row_step = 36
+    src.is_dense = True
+    src.fields = [
+        PointField(name="x", offset=0, datatype=PointField.FLOAT32, count=1),
+        PointField(name="y", offset=4, datatype=PointField.FLOAT32, count=1),
+        PointField(name="z", offset=8, datatype=PointField.FLOAT32, count=1),
+    ]
+    src.data = bytes(range(36))
+
+    meta, view = supported_types.PointCloud2.to_shm_payload(src)
+    out = supported_types.PointCloud2.from_shm_payload(meta, bytes(view))
+    assert (out.height, out.width, out.point_step, out.row_step) == (1, 3, 12, 36)
+    assert out.is_dense
+    assert out.header.frame_id == "lidar"
+    assert bytes(out.data) == bytes(src.data)
+    assert [(f.name, f.offset, f.datatype, f.count) for f in out.fields] == [
+        ("x", 0, PointField.FLOAT32, 1),
+        ("y", 4, PointField.FLOAT32, 1),
+        ("z", 8, PointField.FLOAT32, 1),
+    ]
+
+
+def test_type_without_override_has_no_shm_payload():
+    # A type that does not override the hook falls through to CDR (None), and
+    # its base from_shm_payload must never run.
+    assert supported_types.Odometry.to_shm_payload(Odometry()) is None
+    with pytest.raises(NotImplementedError):
+        supported_types.Odometry.from_shm_payload({}, b"")

--- a/test/io_types_test.py
+++ b/test/io_types_test.py
@@ -1433,3 +1433,114 @@ def test_type_without_override_has_no_shm_payload():
     assert supported_types.Odometry.to_shm_payload(Odometry()) is None
     with pytest.raises(NotImplementedError):
         supported_types.Odometry.from_shm_payload({}, b"")
+
+
+# ---------------------------------------------------------------------------
+# Large payload fields take the generated setter's fast path
+# ---------------------------------------------------------------------------
+# rosidl assigns an array.array of the field's typecode as is; anything else is
+# walked element by element in Python, and on distributions that validate
+# fields it is walked twice more first. The property under test is therefore
+# "the field is an array.array of the right typecode", not just its content.
+
+
+def test_image_from_numpy_takes_the_fast_path():
+    import array
+
+    from ros_sugar.io.supported_types import Image
+
+    frame = np.arange(4 * 6 * 3, dtype=np.uint8).reshape(4, 6, 3)
+    msg = Image.convert(frame)
+    assert isinstance(msg.data, array.array) and msg.data.typecode == "B"
+    assert msg.data.tobytes() == frame.tobytes()
+    assert (msg.height, msg.width) == (4, 6)
+
+
+def test_compressed_image_from_numpy_takes_the_fast_path():
+    import array
+
+    from ros_sugar.io.supported_types import CompressedImage
+
+    encoded = np.frombuffer(b"\xff\xd8 not really a jpeg \xff\xd9", dtype=np.uint8)
+    msg = CompressedImage.convert(encoded)
+    assert isinstance(msg.data, array.array) and msg.data.typecode == "B"
+    assert msg.data.tobytes() == encoded.tobytes()
+
+
+def test_shared_memory_rebuild_takes_the_fast_path():
+    """The consumer-side rebuild after a shared-memory hand-off is done once
+    per frame per consumer; it must copy the buffer, not walk it."""
+    import array
+
+    from sensor_msgs.msg import CompressedImage as ROSCompressedImage
+    from sensor_msgs.msg import Image as ROSImage
+    from sensor_msgs.msg import PointCloud2 as ROSPointCloud2
+    from sensor_msgs.msg import PointField
+
+    from ros_sugar.io.supported_types import CompressedImage, Image, PointCloud2
+
+    image = ROSImage()
+    image.header.frame_id = "cam"
+    image.height, image.width, image.encoding, image.step = 2, 3, "rgb8", 9
+    image.data = array.array("B", bytes(range(18)))
+
+    compressed = ROSCompressedImage()
+    compressed.header.frame_id = "cam"
+    compressed.format = "jpeg"
+    compressed.data = array.array("B", b"\xff\xd8\x00\x01\xff\xd9")
+
+    cloud = ROSPointCloud2()
+    cloud.header.frame_id = "lidar"
+    cloud.height, cloud.width, cloud.point_step, cloud.row_step = 1, 2, 16, 32
+    cloud.fields = [
+        PointField(name=n, offset=o, datatype=PointField.FLOAT32, count=1)
+        for n, o in (("x", 0), ("y", 4), ("z", 8))
+    ]
+    cloud.data = array.array("B", bytes(range(32)))
+
+    for kind, msg in ((Image, image), (CompressedImage, compressed), (PointCloud2, cloud)):
+        meta, view = kind.to_shm_payload(msg)
+        # the reader hands back a copy of the slot as bytes
+        rebuilt = kind.from_shm_payload(meta, bytes(view))
+        assert isinstance(rebuilt.data, array.array) and rebuilt.data.typecode == "B"
+        assert rebuilt.data.tobytes() == msg.data.tobytes()
+        assert rebuilt.header.frame_id == msg.header.frame_id
+
+
+def test_grid_from_numpy_takes_the_fast_path_and_keeps_column_order():
+    import array
+
+    from ros_sugar.io.supported_types import OccupancyGrid as GridType
+
+    from ros_sugar.io.callbacks import OccupancyGridCallback
+
+    # non-square, every cell distinct: a transposed or row-major flatten would
+    # show up in the element order and in the decoded shape
+    grid = np.array([[0, 100, 25], [-1, 50, 75]], dtype=np.int8)
+    msg = GridType.convert(grid, resolution=0.1)
+    assert isinstance(msg.data, array.array) and msg.data.typecode == "b"
+    # flattened by column, unknown cells stay -1
+    assert list(msg.data) == [0, -1, 100, 50, 25, 75]
+    assert (msg.info.width, msg.info.height) == (2, 3)
+
+    # and the callback reads the very same grid back
+    reader = OccupancyGridCallback(Topic(name="/map", msg_type="OccupancyGrid"))
+    reader.callback(msg)
+    assert np.array_equal(np.asarray(reader.get_output(get_obstacles=False)), grid)
+
+
+def test_multiarray_from_numpy_takes_the_fast_path():
+    import array
+
+    from std_msgs.msg import Float32MultiArray, Float64MultiArray
+
+    from ros_sugar.io.utils import numpy_to_multiarray
+
+    values = np.arange(6, dtype=np.float64).reshape(2, 3) / 4
+    single = numpy_to_multiarray(values, Float32MultiArray)
+    double = numpy_to_multiarray(values, Float64MultiArray)
+    assert isinstance(single.data, array.array) and single.data.typecode == "f"
+    assert isinstance(double.data, array.array) and double.data.typecode == "d"
+    assert list(double.data) == values.flatten().tolist()
+    assert np.allclose(list(single.data), values.flatten())
+    assert [dim.size for dim in double.layout.dim] == [2, 3]

--- a/test/launch_actions_test.py
+++ b/test/launch_actions_test.py
@@ -1,0 +1,75 @@
+"""Tests for the in-process (multithreaded) component launch action.
+
+Regression coverage for launch shutdown under an internal-event flood: the
+OnShutdown handler that stops a component's executor runs on launch's asyncio
+loop, behind every event already queued there. A node firing events at rate
+kept that queue full, so the handler starved and the node kept spinning,
+feeding it further -- and launch never shut down.
+"""
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+import rclpy
+from launch import LaunchContext
+
+from ros_sugar.core.component import BaseComponent
+from ros_sugar.launch.launch_actions import ComponentLaunchAction
+
+
+@pytest.fixture
+def running_action():
+    """A component spinning in its executor thread, the way launch runs it."""
+    component = BaseComponent(component_name="launch_action_component")
+    action = ComponentLaunchAction(node=component, name=component.node_name)
+    context = LaunchContext()
+    action.execute(context)
+    try:
+        yield action, context
+    finally:
+        if action._ComponentLaunchAction__is_running:
+            action.shutdown()
+
+
+def _spin_thread(action):
+    return action._ComponentLaunchAction__ros_executor_thread
+
+
+def test_spin_loop_stops_when_launch_requests_shutdown(running_action):
+    """The executor thread has to exit on the context's shutdown flag alone,
+    without waiting for the OnShutdown handler that may never get through."""
+    action, context = running_action
+    assert _spin_thread(action).is_alive()
+
+    # What LaunchService._shutdown does synchronously, before the Shutdown
+    # event reaches the loop
+    context._set_is_shutdown(True)
+
+    _spin_thread(action).join(timeout=2.0)
+    assert not _spin_thread(action).is_alive(), (
+        "executor kept spinning after launch asked to shut down"
+    )
+    # The regular handler still runs afterwards and must not trip over the
+    # thread having exited on its own
+    action.shutdown()
+
+
+def test_spin_loop_keeps_running_until_asked(running_action):
+    action, _ = running_action
+    time.sleep(0.2)
+    assert _spin_thread(action).is_alive()
+
+
+def test_internal_events_are_dropped_once_shutdown_is_requested(running_action):
+    """Every event queued after the request only delays the Shutdown event."""
+    action, context = running_action
+    loop = MagicMock()
+    context._set_asyncio_loop(loop)
+
+    action._on_internal_event("some_event")
+    assert loop.call_soon_threadsafe.call_count == 1, "events must flow before shutdown"
+
+    context._set_is_shutdown(True)
+    action._on_internal_event("some_event")
+    assert loop.call_soon_threadsafe.call_count == 1, "event queued after shutdown"

--- a/test/plugin_processes_test.py
+++ b/test/plugin_processes_test.py
@@ -1,0 +1,374 @@
+"""Tests for plugin-declared driver processes and recipe demand propagation.
+
+Covers `Plugin.requested_feedbacks` / `requested_commands` — what a recipe
+actually asked a plugin for — and `Plugin.required_processes`, which lets a
+plugin have the launcher bring up the driver node its data depends on.
+"""
+
+import pytest
+from launch_ros.actions import Node as NodeLaunchAction
+
+from ros_sugar import Launcher
+from ros_sugar.io.topic import Topic
+from ros_sugar.robot import (
+    Feedback,
+    PluginMetadata,
+    ProcessSpec,
+    RobotCommand,
+    RobotPlugin,
+)
+from ros_sugar.robot.transports.udp import UdpTransport
+
+from ros_sugar.io.supported_types import LaserScan, Odometry, Twist
+
+
+class _DriverPlugin(RobotPlugin):
+    """A robot plugin with two same-typed feedbacks and one command.
+
+    Two `LaserScan` feedbacks is the interesting case: it forces recipes to
+    name the plugin's key rather than lean on the unique-type fallback, which
+    is exactly the shape of a robot with a front and a rear lidar.
+    """
+
+    def __init__(self):
+        self.metadata = PluginMetadata(name="DriverBot", vendor="test")
+        transport = UdpTransport("state", send_to=("127.0.0.1", 45999))
+        self.transports = {"robot": transport}
+        self.feedbacks = {
+            "scan_front": Feedback(
+                key="scan_front", msg_type=LaserScan, transport=transport,
+                decoder=lambda raw: None,
+            ),
+            "scan_back": Feedback(
+                key="scan_back", msg_type=LaserScan, transport=transport,
+                decoder=lambda raw: None,
+            ),
+            "odom": Feedback(
+                key="odom", msg_type=Odometry, transport=transport,
+                decoder=lambda raw: None,
+            ),
+        }
+        self.commands = {
+            "cmd_vel": RobotCommand(
+                key="cmd_vel", msg_type=Twist, transport=transport,
+                encoder=lambda out: b"",
+            )
+        }
+        # Test hooks
+        self.seen_at_attach = None
+        self.precondition_result = True
+        self.declare_raises = False
+
+    def required_processes(self):
+        if self.declare_raises:
+            raise RuntimeError("boom")
+        if not {"scan_front", "scan_back"} & self.requested_feedbacks:
+            return []
+        return [
+            ProcessSpec(
+                package="fake_lidar_pkg",
+                executable="fake_lidar_node",
+                name="lidar_driver",
+                precondition=lambda: self.precondition_result,
+            )
+        ]
+
+    def on_attached(self, node, bus) -> None:
+        # Demand must already be populated by the time this runs.
+        self.seen_at_attach = self.requested_feedbacks
+
+
+class _FakeComponent:
+    """Minimum surface the launcher's demand pass needs."""
+
+    def __init__(self, node_name, in_topics=None, out_topics=None):
+        self.node_name = node_name
+        self.in_topics = in_topics or []
+        self.out_topics = out_topics or []
+
+
+def _launcher_with(plugin, components):
+    launcher = Launcher(robot_plugin=plugin)
+    launcher._components = components
+    return launcher
+
+
+# --- demand resolution ---------------------------------------------------
+
+
+def test_demand_resolves_by_plugin_key():
+    plugin = _DriverPlugin()
+    comp = _FakeComponent(
+        "a", in_topics=[Topic(name="scan_front", msg_type="LaserScan", use_plugin=True)]
+    )
+    _launcher_with(plugin, [comp])._resolve_plugin_demand()
+
+    assert plugin.requested_feedbacks == frozenset({"scan_front"})
+    assert plugin.requested_commands == frozenset()
+
+
+def test_demand_resolves_by_unique_type_fallback():
+    """``Odometry`` is unique on this plugin, so the topic name need not match."""
+    plugin = _DriverPlugin()
+    comp = _FakeComponent(
+        "a", in_topics=[Topic(name="whatever", msg_type="Odometry", use_plugin=True)]
+    )
+    _launcher_with(plugin, [comp])._resolve_plugin_demand()
+
+    assert plugin.requested_feedbacks == frozenset({"odom"})
+
+
+def test_demand_resolves_commands_from_out_topics():
+    plugin = _DriverPlugin()
+    comp = _FakeComponent(
+        "a", out_topics=[Topic(name="cmd_vel", msg_type="Twist", use_plugin=True)]
+    )
+    _launcher_with(plugin, [comp])._resolve_plugin_demand()
+
+    assert plugin.requested_commands == frozenset({"cmd_vel"})
+    assert plugin.requested_feedbacks == frozenset()
+
+
+def test_demand_unions_across_components():
+    plugin = _DriverPlugin()
+    comps = [
+        _FakeComponent(
+            "a",
+            in_topics=[Topic(name="scan_front", msg_type="LaserScan", use_plugin=True)],
+        ),
+        _FakeComponent(
+            "b",
+            in_topics=[Topic(name="scan_back", msg_type="LaserScan", use_plugin=True)],
+        ),
+    ]
+    _launcher_with(plugin, comps)._resolve_plugin_demand()
+
+    assert plugin.requested_feedbacks == frozenset({"scan_front", "scan_back"})
+
+
+def test_topics_not_bound_to_a_plugin_are_ignored():
+    plugin = _DriverPlugin()
+    comp = _FakeComponent(
+        "a", in_topics=[Topic(name="scan_front", msg_type="LaserScan")]
+    )
+    _launcher_with(plugin, [comp])._resolve_plugin_demand()
+
+    assert plugin.requested_feedbacks == frozenset()
+
+
+def test_ambiguous_reference_does_not_escape_the_demand_pass():
+    """Two feedbacks share ``LaserScan``; a topic named after neither is
+    ambiguous. The component reports that and falls back — resolving demand
+    must not turn it into a bringup failure."""
+    plugin = _DriverPlugin()
+    comp = _FakeComponent(
+        "a", in_topics=[Topic(name="unmatched", msg_type="LaserScan", use_plugin=True)]
+    )
+    launcher = _launcher_with(plugin, [comp])
+
+    launcher._resolve_plugin_demand()  # must not raise
+
+    assert plugin.requested_feedbacks == frozenset()
+
+
+def test_type_mismatch_on_key_match_does_not_escape():
+    plugin = _DriverPlugin()
+    comp = _FakeComponent(
+        "a", in_topics=[Topic(name="scan_front", msg_type="Odometry", use_plugin=True)]
+    )
+    launcher = _launcher_with(plugin, [comp])
+
+    launcher._resolve_plugin_demand()  # must not raise
+
+    assert plugin.requested_feedbacks == frozenset()
+
+
+def test_demand_defaults_empty_without_a_launcher():
+    """A plugin nobody asked anything of requests nothing — notably not
+    'everything', which would have a standalone host start every driver."""
+    plugin = _DriverPlugin()
+
+    assert plugin.requested_feedbacks == frozenset()
+    assert plugin.requested_commands == frozenset()
+    assert plugin.required_processes() == []
+
+
+# --- process declaration -------------------------------------------------
+
+
+def test_declared_driver_becomes_a_launch_action():
+    plugin = _DriverPlugin()
+    comp = _FakeComponent(
+        "a", in_topics=[Topic(name="scan_front", msg_type="LaserScan", use_plugin=True)]
+    )
+    launcher = _launcher_with(plugin, [comp])
+    launcher._resolve_plugin_demand()
+    launcher._launch_plugin_processes(plugin)
+
+    nodes = [e for e in launcher._description.entities
+             if isinstance(e, NodeLaunchAction)]
+    assert len(nodes) == 1
+
+
+def test_no_driver_when_no_component_wants_the_feedback():
+    plugin = _DriverPlugin()
+    comp = _FakeComponent(
+        "a", out_topics=[Topic(name="cmd_vel", msg_type="Twist", use_plugin=True)]
+    )
+    launcher = _launcher_with(plugin, [comp])
+    launcher._resolve_plugin_demand()
+    launcher._launch_plugin_processes(plugin)
+
+    assert not [e for e in launcher._description.entities
+                if isinstance(e, NodeLaunchAction)]
+
+
+def test_failing_precondition_skips_the_driver():
+    """The already-running case: the vendor's own driver holds the port."""
+    plugin = _DriverPlugin()
+    plugin.precondition_result = False
+    comp = _FakeComponent(
+        "a", in_topics=[Topic(name="scan_front", msg_type="LaserScan", use_plugin=True)]
+    )
+    launcher = _launcher_with(plugin, [comp])
+    launcher._resolve_plugin_demand()
+    launcher._launch_plugin_processes(plugin)
+
+    assert not [e for e in launcher._description.entities
+                if isinstance(e, NodeLaunchAction)]
+
+
+def test_a_raising_declaration_does_not_stop_bringup():
+    plugin = _DriverPlugin()
+    plugin.declare_raises = True
+    launcher = _launcher_with(plugin, [])
+
+    launcher._launch_plugin_processes(plugin)  # must not raise
+
+    assert not [e for e in launcher._description.entities
+                if isinstance(e, NodeLaunchAction)]
+
+
+def test_plugins_without_the_hook_are_unaffected():
+    """The whole feature is a no-op for a plugin that does not opt in."""
+
+    class _Plain(RobotPlugin):
+        def __init__(self):
+            self.metadata = PluginMetadata(name="Plain")
+
+    plugin = _Plain()
+    launcher = _launcher_with(plugin, [])
+    launcher._launch_plugin_processes(plugin)
+
+    assert plugin.required_processes() == []
+    assert not [e for e in launcher._description.entities
+                if isinstance(e, NodeLaunchAction)]
+
+
+# --- spec ----------------------------------------------------------------
+
+
+def test_launch_kwargs_omits_precondition():
+    spec = ProcessSpec(package="p", executable="e", precondition=lambda: True)
+    kwargs = spec.launch_kwargs()
+
+    assert "precondition" not in kwargs
+    assert kwargs["package"] == "p"
+    assert kwargs["respawn"] is True
+
+
+def test_spec_label_falls_back_to_package_and_executable():
+    assert ProcessSpec(package="p", executable="e").label == "p/e"
+    assert ProcessSpec(package="p", executable="e", name="n").label == "n"
+
+
+# --- ordering, through the real _setup_plugins path ----------------------
+
+
+class _RosDriverPlugin(RobotPlugin):
+    """Same shape as `_DriverPlugin` but on ROS transports, which the host
+    skips — so `_setup_plugins` can be run whole without opening a socket."""
+
+    def __init__(self):
+        from ros_sugar.robot import RosTopicTransport
+
+        self.metadata = PluginMetadata(name="RosDriverBot", vendor="test")
+        transport = RosTopicTransport(
+            "scan", topic_name="/scan", msg_type=LaserScan
+        )
+        self.transports = {"scan": transport}
+        self.feedbacks = {
+            "scan_front": Feedback(
+                key="scan_front", msg_type=LaserScan, transport=transport
+            )
+        }
+        self.seen_at_attach = None
+
+    def required_processes(self):
+        if "scan_front" not in self.requested_feedbacks:
+            return []
+        return [ProcessSpec(package="fake_lidar_pkg", executable="fake_lidar_node")]
+
+    def on_attached(self, node, bus) -> None:
+        self.seen_at_attach = self.requested_feedbacks
+
+
+class _FakeMonitorNode:
+    def feed_external_topic(self, channel, msg):
+        pass
+
+    def register_external_topic(self, topic):
+        pass
+
+
+@pytest.fixture
+def wired_launcher():
+    plugin = _RosDriverPlugin()
+    launcher = Launcher(robot_plugin=plugin)
+    launcher._components = [
+        _FakeComponent(
+            "a",
+            in_topics=[
+                Topic(name="scan_front", msg_type="LaserScan", use_plugin=True)
+            ],
+        )
+    ]
+    launcher.monitor_node = _FakeMonitorNode()
+    yield launcher, plugin
+    for host in launcher._plugin_hosts:
+        host.close()
+
+
+def _node_actions(launcher):
+    return [e for e in launcher._description.entities
+            if isinstance(e, NodeLaunchAction)]
+
+
+def test_on_attached_sees_the_resolved_demand(wired_launcher):
+    """The ordering the whole design rests on: demand is populated before any
+    plugin hook runs, so a plugin can act on it."""
+    launcher, plugin = wired_launcher
+
+    launcher._setup_plugins()
+
+    assert plugin.seen_at_attach == frozenset({"scan_front"})
+
+
+def test_setup_plugins_starts_the_declared_driver(wired_launcher):
+    launcher, _ = wired_launcher
+
+    launcher._setup_plugins()
+
+    assert len(_node_actions(launcher)) == 1
+
+
+def test_setup_plugins_is_idempotent(wired_launcher):
+    """``setup_launch_description`` is public; running the plugin setup twice
+    must not start the driver twice or open a second host."""
+    launcher, _ = wired_launcher
+
+    launcher._setup_plugins()
+    launcher._setup_plugins()
+
+    assert len(_node_actions(launcher)) == 1
+    assert len(launcher._plugin_hosts) == 1

--- a/test/robot_config_test.py
+++ b/test/robot_config_test.py
@@ -35,7 +35,7 @@ def robot_config(**overrides) -> RobotConfig:
         "geometry_params": [0.2, 1.0],
         "ctrl_vx_limits": LinearCtrlLimits(max_vel=1.0, max_acc=3.0, max_decel=5.0),
         "ctrl_omega_limits": AngularCtrlLimits(
-            max_vel=5.0, max_steer=math.pi, max_acc=10.0, max_decel=10.0
+            max_omega=5.0, max_ang=math.pi, max_acc=10.0, max_decel=10.0
         ),
         **overrides,
     })
@@ -197,3 +197,19 @@ def test_component_config_carries_robot_and_frames():
     assert rebuilt.robot.geometry_type is RobotGeometryType.SPHERE
     assert rebuilt.frames.robot_base == "body"
     assert rebuilt.frames.world == "odom"
+
+
+def test_zero_minimum_velocities_are_rejected():
+    """A minimum velocity of zero is no deadband at all, so both limits
+    classes refuse it while a positive value is accepted."""
+    LinearCtrlLimits(max_vel=1.0, max_acc=3.0, max_decel=5.0, min_vel=0.05)
+    with pytest.raises(ValueError):
+        LinearCtrlLimits(max_vel=1.0, max_acc=3.0, max_decel=5.0, min_vel=0.0)
+
+    AngularCtrlLimits(
+        max_omega=5.0, max_ang=math.pi, max_acc=10.0, max_decel=10.0, min_omega=0.05
+    )
+    with pytest.raises(ValueError):
+        AngularCtrlLimits(
+            max_omega=5.0, max_ang=math.pi, max_acc=10.0, max_decel=10.0, min_omega=0.0
+        )

--- a/test/robot_plugin_test.py
+++ b/test/robot_plugin_test.py
@@ -1322,7 +1322,7 @@ class _DescribingPlugin(RobotPlugin):
             geometry_params=np.array([0.61, 0.37, 0.4]),
             ctrl_vx_limits=LinearCtrlLimits(max_vel=1.0, max_acc=2.5, max_decel=7.5),
             ctrl_omega_limits=AngularCtrlLimits(
-                max_vel=1.5, max_acc=2.5, max_decel=4.0, max_steer=1.57
+                max_omega=1.5, max_acc=2.5, max_decel=4.0, max_ang=1.57
             ),
         )
         self.base_frame = "lite3_base"

--- a/test/robot_plugin_test.py
+++ b/test/robot_plugin_test.py
@@ -2789,3 +2789,52 @@ def test_robot_plugin_sensor_mounts_are_collected_by_the_launcher():
     plugin.mounts = [Mount(parent=plugin, xyz=(0.3, 0.0, 0.0))]
     with pytest.raises(ValueError, match="child"):
         Launcher(robot_plugin=plugin)
+
+
+def _make_map_store(tmp_path, active_name, files):
+    """A map store with one map, marked active by a symlink."""
+    store = tmp_path / "maps"
+    mapdir = store / active_name
+    mapdir.mkdir(parents=True)
+    for f in files:
+        (mapdir / f).write_text("image: x\n")
+    (store / "active").symlink_to(mapdir)
+    return str(store)
+
+
+def test_active_grid_path_prefers_the_declared_name(tmp_path):
+    store = _make_map_store(tmp_path, "map-20260101-100000",
+                            ["occ_grid.yaml", "full_cloud.pcd"])
+    decl = VendorMapping(start=["x"], stop=["y"], store=store)
+    assert decl.active_grid_path().endswith("occ_grid.yaml")
+
+
+def test_active_grid_path_discovers_an_unconventional_name(tmp_path):
+    """A map imported rather than built by the vendor's own tool can use any
+    filename -- assuming occ_grid.yaml is what breaks a recipe."""
+    store = _make_map_store(tmp_path, "map-20260807-153443", ["office.yaml"])
+    decl = VendorMapping(start=["x"], stop=["y"], store=store)
+    assert decl.active_grid_path().endswith("office.yaml")
+
+
+def test_active_grid_path_refuses_to_guess(tmp_path):
+    """Two candidates and no declared name: returning either would be a coin
+    flip a recipe would silently navigate on."""
+    store = _make_map_store(tmp_path, "m-20260101-100000", ["a.yaml", "b.yaml"])
+    decl = VendorMapping(start=["x"], stop=["y"], store=store, grid="")
+    assert decl.active_grid_path() is None
+
+
+def test_active_grid_path_without_a_store_or_active_map(tmp_path):
+    assert VendorMapping(start=["x"], stop=["y"], store="").active_grid_path() is None
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    decl = VendorMapping(start=["x"], stop=["y"], store=str(empty))
+    assert decl.active_grid_path() is None
+
+
+def test_native_mapping_answers_the_same_question(tmp_path):
+    """A recipe should not have to know which provider it is talking to."""
+    store = _make_map_store(tmp_path, "room-20260101-100000", ["occ_grid.yaml"])
+    decl = NativeMapping(cloud="lidar", store=store)
+    assert decl.active_grid_path().endswith("occ_grid.yaml")

--- a/test/robot_plugin_test.py
+++ b/test/robot_plugin_test.py
@@ -2687,3 +2687,25 @@ def test_ros_topic_feedback_keeps_the_recipe_name(rclpy_context):
         assert component.callbacks["other"]._subscriber.topic_name == "/other"
     finally:
         component.destroy_node()
+
+
+def test_robot_plugin_sensor_mounts_are_collected_by_the_launcher():
+    """A robot plugin places its own built-in sensors through ``mounts``;
+    the launcher publishes them like a sensor plugin's mount."""
+    from ros_sugar import Launcher
+    from ros_sugar.robot import Mount
+
+    plugin = MockPlugin(state_port=_free_port(), cmd_port=_free_port())
+    plugin.base_frame = "base"
+    plugin.mounts = [Mount(parent=plugin, child="sonar_front", xyz=(0.3, 0.0, 0.0))]
+    launcher = Launcher(robot_plugin=plugin)
+    assert [(m.parent_frame, m.child_frame) for m in launcher._mounts] == [
+        ("base", "sonar_front")
+    ]
+
+    # A mount that names no frame cannot be placed
+    plugin = MockPlugin(state_port=_free_port(), cmd_port=_free_port())
+    plugin.base_frame = "base"
+    plugin.mounts = [Mount(parent=plugin, xyz=(0.3, 0.0, 0.0))]
+    with pytest.raises(ValueError, match="child"):
+        Launcher(robot_plugin=plugin)

--- a/test/robot_plugin_test.py
+++ b/test/robot_plugin_test.py
@@ -2262,6 +2262,44 @@ def test_setup_plugins_hosts_every_plugin_on_one_bus(rclpy_context):
             launcher._plugin_bus.close()
 
 
+def test_setup_plugins_creates_and_injects_shm_manager(rclpy_context):
+    """On the socket bus the launcher creates one shared-memory writer pool and
+    injects it into every host; the in-process bus needs none."""
+    from ros_sugar.robot.shm import PluginShmManager
+
+    # Socket bus (multiprocess): a non-empty _pkg_executable forces it.
+    launcher = _launcher_with([])
+    launcher.monitor_node = _StubMonitor()
+    launcher._pkg_executable = {"c": ("pkg", "entry")}
+    launcher.add_plugin(MockUdpSensor(state_port=_free_port(), id="cam"))
+    try:
+        launcher._setup_plugins()
+        assert isinstance(launcher._plugin_shm, PluginShmManager)
+        assert launcher._plugin_hosts
+        assert all(h._shm is launcher._plugin_shm for h in launcher._plugin_hosts)
+    finally:
+        for host in launcher._plugin_hosts:
+            host.close()
+        if launcher._plugin_bus:
+            launcher._plugin_bus.close()
+        if launcher._plugin_shm:
+            launcher._plugin_shm.close()
+
+    # In-process bus: no manager, and hosts get shm=None.
+    launcher2 = _launcher_with([])
+    launcher2.monitor_node = _StubMonitor()
+    launcher2.add_plugin(MockUdpSensor(state_port=_free_port(), id="cam2"))
+    try:
+        launcher2._setup_plugins()
+        assert launcher2._plugin_shm is None
+        assert all(h._shm is None for h in launcher2._plugin_hosts)
+    finally:
+        for host in launcher2._plugin_hosts:
+            host.close()
+        if launcher2._plugin_bus:
+            launcher2._plugin_bus.close()
+
+
 def test_setup_plugins_registers_each_plugins_feedback_with_the_monitor(rclpy_context):
     """Events over non-ROS feedback are tracked without a ROS subscription, so
     every plugin's channels have to reach the Monitor -- namespaced, or two

--- a/test/robot_plugin_test.py
+++ b/test/robot_plugin_test.py
@@ -17,7 +17,10 @@ import pytest
 import rclpy
 from std_msgs.msg import Int32 as RosInt32
 
+from rclpy import qos
+from ros_sugar.config import QoSConfig
 from ros_sugar.io.topic import Topic
+from ros_sugar.supported_types import LaserScan
 from ros_sugar.robot import (
     ActionRegistry,
     EventRegistry,
@@ -2613,3 +2616,74 @@ def test_shm_descriptor_is_tiny_on_the_wire():
         assert len(payload) < 1024  # a descriptor crossed the wire, not the frame
     finally:
         manager.close()
+
+
+class _RosCloudPlugin(RobotPlugin):
+    """A plugin serving one sensor over a ROS topic of its own, the way a
+    LiDAR driver started by the plugin publishes."""
+
+    def __init__(self):
+        from ros_sugar.robot import RosTopicTransport
+
+        self.metadata = PluginMetadata(name="RosCloudBot", vendor="test")
+        transport = RosTopicTransport(
+            "lidar_front",
+            topic_name="rs/front/points",
+            msg_type=LaserScan,
+            qos=QoSConfig(reliability=qos.ReliabilityPolicy.BEST_EFFORT),
+        )
+        self.transports = {"lidar_front": transport}
+        self.feedbacks = {
+            "lidar_front": Feedback(
+                key="lidar_front", msg_type=LaserScan, transport=transport
+            )
+        }
+
+
+def test_ros_topic_feedback_keeps_the_recipe_name(rclpy_context):
+    """A plugin serving an input over a ROS topic changes where the input is
+    subscribed, not what it is called. The callbacks key, ``in_topics`` and
+    any name a component recorded stay the recipe's; the subscriber alone
+    sits on the plugin's topic with the plugin's QoS, and a message published
+    there lands in the recipe's slot."""
+    from sensor_msgs.msg import LaserScan as RosLaserScan
+
+    from ros_sugar.core.component import BaseComponent
+
+    component = BaseComponent(
+        component_name="ros_feedback_component",
+        inputs=[Topic(name="lidar_front", msg_type="LaserScan", use_plugin=True)],
+    )
+    component.rclpy_init_node()
+    component._robot_plugin = _RosCloudPlugin()
+    try:
+        component._use_robot_plugin()
+        assert list(component.callbacks) == ["lidar_front"]
+        assert component.in_topics[0].name == "lidar_front"
+        # a ROS subscription, not the plugin bus
+        assert "lidar_front" not in component._external_topics
+
+        component.create_all_subscribers()
+        subscriber = component.callbacks["lidar_front"]._subscriber
+        assert subscriber.topic_name == "/rs/front/points"
+        assert (
+            subscriber.qos_profile.reliability == qos.ReliabilityPolicy.BEST_EFFORT
+        )
+
+        publisher = component.create_publisher(RosLaserScan, "rs/front/points", 10)
+        scan = RosLaserScan()
+        scan.header.frame_id = "rslidar_front"
+        callback = component.callbacks["lidar_front"]
+        deadline = time.time() + 2.0
+        while callback.msg is None and time.time() < deadline:
+            publisher.publish(scan)
+            rclpy.spin_once(component, timeout_sec=0.05)
+        assert callback.msg is not None
+        assert callback.frame_id == "rslidar_front"
+
+        # the explicit swap is the one thing that changes identity
+        assert component._replace_input_topic("lidar_front", "/other", "LaserScan") is None
+        assert list(component.callbacks) == ["other"]
+        assert component.callbacks["other"]._subscriber.topic_name == "/other"
+    finally:
+        component.destroy_node()

--- a/test/robot_plugin_test.py
+++ b/test/robot_plugin_test.py
@@ -2381,3 +2381,112 @@ def test_publishing_mounts_is_a_noop_without_any(rclpy_context):
         assert not hasattr(node, "_pending")
     finally:
         node.destroy_node()
+
+
+# ---------------------------------------------------------------------------
+# Shared-memory feedback encode/decode (socket-bus fast path)
+# ---------------------------------------------------------------------------
+
+
+def _image_sensor():
+    """A minimal sensor plugin exposing one built-in Image feedback."""
+    from ros_sugar.supported_types import Image
+
+    class _ImageSensor(SensorPlugin):
+        def __init__(self):
+            self.metadata = PluginMetadata(name="ImageSensor")
+            transport = SdkCallbackTransport("img")
+            self.transports = {"img": transport}
+            self.feedbacks = {
+                "Image": Feedback(
+                    key="Image",
+                    msg_type=Image,
+                    transport=transport,
+                    decoder=lambda raw: raw,
+                )
+            }
+
+    return _ImageSensor()
+
+
+def _image_msg(nbytes: int):
+    from sensor_msgs.msg import Image as ROSImage
+
+    msg = ROSImage()
+    msg.header.frame_id = "cam"
+    msg.height = 1
+    msg.width = nbytes
+    msg.encoding = "mono8"
+    msg.step = nbytes
+    msg.data = bytes((i % 256) for i in range(nbytes))
+    return msg
+
+
+def test_encode_feedback_shm_roundtrip_skips_cdr(monkeypatch):
+    """A large hook-supporting feedback rides shared memory: the payload is
+    tagged SHM, rebuilds byte-identically, and no CDR (de)serialization runs."""
+    import ros_sugar.robot.plugin as plugin_mod
+    from ros_sugar.robot.shm import PluginShmManager, ShmReaderCache
+
+    counts = {"ser": 0, "deser": 0}
+    _ser, _deser = plugin_mod.serialize_message, plugin_mod.deserialize_message
+    monkeypatch.setattr(
+        plugin_mod,
+        "serialize_message",
+        lambda m: (counts.__setitem__("ser", counts["ser"] + 1), _ser(m))[1],
+    )
+    monkeypatch.setattr(
+        plugin_mod,
+        "deserialize_message",
+        lambda d, t: (counts.__setitem__("deser", counts["deser"] + 1), _deser(d, t))[1],
+    )
+
+    sensor = _image_sensor()
+    fb = sensor.feedbacks["Image"]
+    manager = PluginShmManager(launcher_pid=4321)
+    host = RobotPluginHost(sensor, node=None, bus=InProcessFeedbackBus(), shm=manager)
+    try:
+        big = _image_msg(40_000)  # >= SHM_MIN_BYTES
+        payload = host._encode_feedback(fb, big)
+        assert payload[:1] == plugin_mod._FB_KIND_SHM
+
+        reader = ShmReaderCache()
+        out = plugin_mod._decode_shm_feedback(fb, reader, payload[1:])
+        reader.close()
+
+        assert bytes(out.data) == bytes(big.data)
+        assert out.encoding == "mono8"
+        assert out.header.frame_id == "cam"
+        assert counts == {"ser": 0, "deser": 0}  # SHM path pays no CDR
+    finally:
+        manager.close()
+
+
+def test_encode_feedback_falls_back_to_cdr():
+    """No manager, or a sub-threshold frame, takes the CDR path (tagged CDR)."""
+    import ros_sugar.robot.plugin as plugin_mod
+    from rclpy.serialization import deserialize_message
+    from sensor_msgs.msg import Image as ROSImage
+
+    from ros_sugar.robot.shm import PluginShmManager
+
+    sensor = _image_sensor()
+    fb = sensor.feedbacks["Image"]
+
+    # No manager -> always CDR, even for a large frame.
+    host_no_shm = RobotPluginHost(sensor, node=None, bus=InProcessFeedbackBus())
+    assert host_no_shm._encode_feedback(fb, _image_msg(40_000))[:1] == (
+        plugin_mod._FB_KIND_CDR
+    )
+
+    # Manager present but a sub-threshold frame -> CDR (size gate), and it
+    # deserializes cleanly once the tag byte is stripped.
+    manager = PluginShmManager(launcher_pid=99)
+    host = RobotPluginHost(sensor, node=None, bus=InProcessFeedbackBus(), shm=manager)
+    try:
+        payload = host._encode_feedback(fb, _image_msg(100))
+        assert payload[:1] == plugin_mod._FB_KIND_CDR
+        out = deserialize_message(payload[1:], ROSImage)
+        assert out.encoding == "mono8"
+    finally:
+        manager.close()

--- a/test/robot_plugin_test.py
+++ b/test/robot_plugin_test.py
@@ -511,11 +511,11 @@ def test_plugin_host_feedback_and_command_flow():
     try:
         # A consumer subscribes to the feedback channel as a component would
         decoded = []
-        from rclpy.serialization import deserialize_message
 
+        # In-process bus delivers the live decoded message object (no CDR).
         bus.subscribe(
             "robot/feedback/Int32",
-            lambda data: decoded.append(deserialize_message(data, RosInt32).data),
+            lambda msg: decoded.append(msg.data),
         )
 
         # The robot streams a telemetry packet into the plugin's bound port
@@ -2101,9 +2101,8 @@ def test_unstamped_feedback_is_stamped_with_the_plugin_frame(rclpy_context):
         tx.close()
         assert received, "no feedback arrived"
 
-        from rclpy.serialization import deserialize_message
-
-        msg = deserialize_message(received[0], Imu)
+        # In-process bus delivers the live decoded message object (no CDR).
+        msg = received[0]
         assert msg.header.frame_id == "waist_imu_frame"
     finally:
         handle.unsubscribe()

--- a/test/robot_plugin_test.py
+++ b/test/robot_plugin_test.py
@@ -27,6 +27,7 @@ from ros_sugar.robot import (
     Feedback,
     HttpTransport,
     InProcessFeedbackBus,
+    NativeMapping,
     PluginMetadata,
     RobotCommand,
     RobotPlugin,
@@ -35,6 +36,7 @@ from ros_sugar.robot import (
     SdkCallbackTransport,
     SocketFeedbackBus,
     UdpTransport,
+    VendorMapping,
     create_supported_type,
 )
 
@@ -460,6 +462,84 @@ def test_inspect_cli():
     payload = json.loads(result.stdout)
     assert payload["metadata"]["name"] == "MockPlugin"
     assert [f["key"] for f in payload["feedbacks"]] == ["Int32"]
+
+
+# ---------------------------------------------------------------------------
+# Mapping declarations
+# ---------------------------------------------------------------------------
+
+
+class _VendorMappingPlugin(RobotPlugin):
+    """A robot whose own software builds the map, driven by a vendor tool."""
+
+    MAPPING = VendorMapping(
+        start=["drmap", "mapping", "-b", "-n", "{name}"],
+        stop=["drmap", "stop_mapping"],
+        apply=["drmap", "apply", "{name}"],
+        after_apply=["systemctl", "restart", "localization.service"],
+        store="/var/opt/robot/data/maps",
+        area_limit_m=50.0,
+    )
+
+    def __init__(self):
+        self.metadata = PluginMetadata(name="VendorMapper", vendor="test")
+
+
+class _NativeMappingPlugin(RobotPlugin):
+    """A robot EMOS maps itself, from the plugin's own sensor feedbacks."""
+
+    MAPPING = NativeMapping(cloud="lidar", imu="lidar_imu", z_max=1.2)
+
+    def __init__(self):
+        self.metadata = PluginMetadata(name="NativeMapper", vendor="test")
+
+
+def test_plugin_without_mapping_describes_none():
+    """A plugin that cannot be mapped says so explicitly rather than omitting
+    the key, so a consumer never has to distinguish absent from unmappable."""
+    plugin = MockPlugin(state_port=46030, cmd_port=46031)
+    assert plugin.describe()["mapping"] is None
+
+
+def test_vendor_mapping_reaches_describe():
+    """The declaration survives into the introspection tree, tagged so a
+    consumer can tell the two providers apart."""
+    mapping = _VendorMappingPlugin().describe()["mapping"]
+    assert mapping["kind"] == "vendor"
+    assert mapping["start"] == ["drmap", "mapping", "-b", "-n", "{name}"]
+    assert mapping["after_apply"] == [
+        "systemctl",
+        "restart",
+        "localization.service",
+    ]
+    assert mapping["store"] == "/var/opt/robot/data/maps"
+    # Defaults the declaration did not set.
+    assert mapping["grid"] == "occ_grid.yaml"
+    assert mapping["cloud"] == "full_cloud.pcd"
+    assert mapping["active_link"] == "active"
+    assert mapping["requires_root"] is True
+    assert mapping["host"] == "local"
+    assert mapping["export"] is None
+
+
+def test_native_mapping_reaches_describe():
+    """Inputs are named by feedback key, not topic, so the plugin stays the
+    single source of truth for the topic behind them."""
+    mapping = _NativeMappingPlugin().describe()["mapping"]
+    assert mapping["kind"] == "native"
+    assert mapping["cloud"] == "lidar"
+    assert mapping["imu"] == "lidar_imu"
+    assert mapping["z_min"] == 0.15
+    assert mapping["z_max"] == 1.2
+    assert mapping["resolution"] == 0.05
+
+
+def test_mapping_spec_is_json_serializable():
+    """``describe`` crosses into the CLI as JSON, so the mapping block must
+    survive the trip with nothing exotic in it."""
+    for plugin in (_VendorMappingPlugin(), _NativeMappingPlugin()):
+        payload = json.loads(json.dumps(plugin.describe()["mapping"]))
+        assert payload["kind"] in {"vendor", "native"}
 
 
 # ---------------------------------------------------------------------------

--- a/test/robot_plugin_test.py
+++ b/test/robot_plugin_test.py
@@ -2528,3 +2528,88 @@ def test_encode_feedback_falls_back_to_cdr():
         assert out.encoding == "mono8"
     finally:
         manager.close()
+
+
+def test_socket_bus_shm_end_to_end(monkeypatch):
+    """A large Image travels host -> component over a real socket bus through
+    shared memory: byte-identical on the far side, and no CDR runs on the
+    payload -- only the tiny descriptor crosses the socket."""
+    import ros_sugar.robot.plugin as plugin_mod
+    from ros_sugar.robot.shm import PluginShmManager
+
+    counts = {"ser": 0, "deser": 0}
+    _ser, _deser = plugin_mod.serialize_message, plugin_mod.deserialize_message
+    monkeypatch.setattr(
+        plugin_mod,
+        "serialize_message",
+        lambda m: (counts.__setitem__("ser", counts["ser"] + 1), _ser(m))[1],
+    )
+    monkeypatch.setattr(
+        plugin_mod,
+        "deserialize_message",
+        lambda d, t: (counts.__setitem__("deser", counts["deser"] + 1), _deser(d, t))[1],
+    )
+
+    # HOST: server socket bus + shm manager
+    server = SocketFeedbackBus()
+    manager = PluginShmManager()
+    host_plugin = _image_sensor()
+    host_plugin._set_id("cam")
+    host_plugin._bind_identity()
+    host = RobotPluginHost(host_plugin, node=None, bus=server, owns_bus=True, shm=manager)
+    host.open()
+
+    # CONSUMER: a second plugin on a client socket bus, as a component process is
+    consumer = _image_sensor()
+    consumer._set_id("cam")
+    consumer._bind_identity()
+    client = SocketFeedbackBus(server.endpoint)
+    client.connect()
+    consumer.set_bus(client)
+
+    received = []
+    handle = consumer.subscribe_feedback(consumer.feedbacks["Image"], received.append)
+    try:
+        time.sleep(0.2)  # let the SUBSCRIBE reach the server before we publish
+        frame = _image_msg(40_000)
+        host._dispatch_feedback(host_plugin.feedbacks["Image"], frame)
+
+        deadline = time.time() + 3.0
+        while not received and time.time() < deadline:
+            time.sleep(0.02)
+        assert received, "no feedback arrived over the socket bus"
+        out = received[0]
+        assert bytes(out.data) == bytes(frame.data)
+        assert out.encoding == "mono8"
+        assert counts == {"ser": 0, "deser": 0}  # traveled via SHM, not CDR
+    finally:
+        handle.unsubscribe()
+        host.close()  # owns_bus=True -> closes the server bus
+        client.close()
+        manager.close()
+
+
+def test_shm_descriptor_is_tiny_on_the_wire():
+    """A full 1080p frame encodes to a small descriptor: the socket carries
+    ~100 bytes, not the ~6 MB frame."""
+    import ros_sugar.robot.plugin as plugin_mod
+    from ros_sugar.robot.shm import PluginShmManager
+    from sensor_msgs.msg import Image as ROSImage
+
+    manager = PluginShmManager()
+    sensor = _image_sensor()
+    host = RobotPluginHost(sensor, node=None, bus=InProcessFeedbackBus(), shm=manager)
+    fb = sensor.feedbacks["Image"]
+    try:
+        frame = ROSImage()
+        frame.height, frame.width = 1080, 1920
+        frame.encoding = "rgb8"
+        frame.step = 1920 * 3
+        frame.data = os.urandom(1920 * 1080 * 3)  # ~6.2 MB 1080p RGB
+        assert len(frame.data) > 6_000_000
+
+        payload = host._encode_feedback(fb, frame)
+        assert payload[:1] == plugin_mod._FB_KIND_SHM
+        assert len(payload) < 1024  # a descriptor crossed the wire, not the frame
+    finally:
+        manager.close()

--- a/test/robot_plugin_test.py
+++ b/test/robot_plugin_test.py
@@ -477,6 +477,7 @@ class _VendorMappingPlugin(RobotPlugin):
         stop=["drmap", "stop_mapping"],
         apply=["drmap", "apply", "{name}"],
         after_apply=["systemctl", "restart", "localization.service"],
+        import_=["drmap", "unpack", "{path}"],
         store="/var/opt/robot/data/maps",
         area_limit_m=50.0,
     )
@@ -520,6 +521,9 @@ def test_vendor_mapping_reaches_describe():
     assert mapping["requires_root"] is True
     assert mapping["host"] == "local"
     assert mapping["export"] is None
+    # The keyword-dodging attribute name does not leak to the CLI.
+    assert mapping["import"] == ["drmap", "unpack", "{path}"]
+    assert "import_" not in mapping
 
 
 def test_native_mapping_reaches_describe():

--- a/test/robot_shm_test.py
+++ b/test/robot_shm_test.py
@@ -1,0 +1,245 @@
+"""Unit tests for the shared-memory feedback ring (`ros_sugar.robot.shm`).
+
+Pure Python -- no ROS graph, no rclpy. Exercises the writer/reader round-trip,
+slot recycling and wraparound, the torn-read seqlock guard, segment growth,
+writer-owns-unlink lifecycle, cross-process reads, and the manager.
+"""
+
+import multiprocessing as mp
+import os
+import struct
+
+import pytest
+
+from ros_sugar.robot.shm import (
+    HEADER_SIZE,
+    SLOT_ENTRY_SIZE,
+    PluginShmManager,
+    ShmDescriptor,
+    ShmReaderCache,
+    ShmRingWriter,
+)
+
+
+def _slot_entry_off(slot: int) -> int:
+    return HEADER_SIZE + slot * SLOT_ENTRY_SIZE
+
+
+def test_descriptor_pack_roundtrip():
+    d = ShmDescriptor(name="sc_1_cam_visible_0", slot=2, seq=17, length=1234, slot_count=4)
+    assert ShmDescriptor.unpack(d.pack()) == d
+
+
+def test_single_reader_roundtrip():
+    writer = ShmRingWriter("sc_test_roundtrip", slot_count=4)
+    reader = ShmReaderCache()
+    try:
+        payloads = [os.urandom(size) for size in (300, 1, 2048, 777)]
+        for i, payload in enumerate(payloads):
+            desc = writer.write(payload)
+            assert desc.slot == i % 4
+            assert desc.seq == i
+            assert reader.read(desc) == payload
+    finally:
+        reader.close()
+        writer.close()
+
+
+def test_wraparound_current_frame_always_valid():
+    writer = ShmRingWriter("sc_test_wrap", slot_count=4)
+    reader = ShmReaderCache()
+    try:
+        for i in range(10):  # more than one full lap of the 4-slot ring
+            payload = os.urandom(300)
+            desc = writer.write(payload)
+            assert desc.slot == i % 4
+            assert reader.read(desc) == payload
+    finally:
+        reader.close()
+        writer.close()
+
+
+def test_recycled_slot_returns_none():
+    writer = ShmRingWriter("sc_test_recycle", slot_count=4)
+    reader = ShmReaderCache()
+    try:
+        stale = writer.write(os.urandom(500))  # seq 0, slot 0
+        for _ in range(4):  # seq 1..4; seq 4 overwrites slot 0
+            writer.write(os.urandom(500))
+        assert reader.read(stale) is None  # slot 0 now holds seq 4, not 0
+    finally:
+        reader.close()
+        writer.close()
+
+
+def test_torn_read_writer_mid_write_returns_none():
+    writer = ShmRingWriter("sc_test_torn_state", slot_count=4)
+    reader = ShmReaderCache()
+    try:
+        payload = os.urandom(800)
+        desc = writer.write(payload)  # slot 0, state committed even
+        buf = writer._shm.buf
+        entry = _slot_entry_off(desc.slot)
+        committed = struct.unpack_from("<Q", buf, entry)[0]
+
+        # Simulate the writer being mid-write: state odd across every retry.
+        struct.pack_into("<Q", buf, entry, committed + 1)
+        assert reader.read(desc) is None
+
+        # Restore the committed (even) state -> the frame reads cleanly again.
+        struct.pack_into("<Q", buf, entry, committed)
+        assert reader.read(desc) == payload
+    finally:
+        reader.close()
+        writer.close()
+
+
+def test_torn_read_frame_seq_mismatch_returns_none():
+    writer = ShmRingWriter("sc_test_torn_seq", slot_count=4)
+    reader = ShmReaderCache()
+    try:
+        payload = os.urandom(800)
+        desc = writer.write(payload)
+        buf = writer._shm.buf
+        entry = _slot_entry_off(desc.slot)
+
+        struct.pack_into("<Q", buf, entry + 8, desc.seq + 999)  # bump frame_seq
+        assert reader.read(desc) is None
+
+        struct.pack_into("<Q", buf, entry + 8, desc.seq)  # restore
+        assert reader.read(desc) == payload
+    finally:
+        reader.close()
+        writer.close()
+
+
+def test_grow_to_new_epoch_keeps_old_readable():
+    writer = ShmRingWriter("sc_test_grow", slot_count=4, min_slot_size=4096)
+    reader = ShmReaderCache()
+    try:
+        small = os.urandom(1000)
+        d_small = writer.write(small)  # slot_size 4096, epoch 0
+
+        big = os.urandom(9000)  # > slot_size -> grow to a new epoch segment
+        d_big = writer.write(big)
+
+        assert d_big.name != d_small.name
+        assert reader.read(d_big) == big
+        assert reader.read(d_small) == small  # retired segment kept alive
+    finally:
+        reader.close()
+        writer.close()
+
+
+def test_reader_never_unlinks_writer_owns():
+    writer = ShmRingWriter("sc_test_owner", slot_count=4)
+    payload = os.urandom(2000)
+    try:
+        desc = writer.write(payload)
+
+        r1 = ShmReaderCache()
+        assert r1.read(desc) == payload
+        r1.close()  # closing a reader must NOT unlink the segment
+
+        r2 = ShmReaderCache()
+        assert r2.read(desc) == payload  # still there
+        r2.close()
+    finally:
+        writer.close()  # the writer is the sole unlinker
+
+    r3 = ShmReaderCache()
+    try:
+        assert r3.read(desc) is None  # segment gone after the writer closed
+    finally:
+        r3.close()
+
+
+def _child_read(desc_bytes, result_q):
+    from ros_sugar.robot.shm import ShmDescriptor, ShmReaderCache
+
+    desc = ShmDescriptor.unpack(desc_bytes)
+    reader = ShmReaderCache()
+    try:
+        result_q.put(reader.read(desc))
+    finally:
+        reader.close()
+
+
+# fork is intentional here: the child only attaches shared memory and reads,
+# touching none of the parent's locks, so the multi-threaded-fork warning is moot.
+# (spawn is not viable -- a pytest test module isn't importable by name in the child.)
+@pytest.mark.filterwarnings("ignore:This process .* is multi-threaded")
+def test_cross_process_read():
+    writer = ShmRingWriter("sc_test_xproc", slot_count=4)
+    ctx = mp.get_context("fork")
+    result_q = ctx.Queue()
+    try:
+        payload = os.urandom(50_000)
+        desc = writer.write(payload)
+        proc = ctx.Process(target=_child_read, args=(desc.pack(), result_q))
+        proc.start()
+        got = result_q.get(timeout=10)
+        proc.join(timeout=10)
+        assert got == payload  # a reader in another process copies the frame out
+    finally:
+        writer.close()
+
+
+def test_manager_writer_reuse_and_teardown():
+    mgr = PluginShmManager(launcher_pid=12345, slot_count=4)
+    payload = os.urandom(1000)
+    try:
+        w1 = mgr.writer_for("cam", "visible_image")
+        assert mgr.writer_for("cam", "visible_image") is w1  # cached per channel
+        w2 = mgr.writer_for("cam", "thermal_image")
+        assert w2 is not w1
+
+        desc = w1.write(payload)
+        assert desc.name.startswith("sc_12345_")
+        reader = ShmReaderCache()
+        assert reader.read(desc) == payload
+        reader.close()
+    finally:
+        mgr.close()
+
+    r = ShmReaderCache()
+    try:
+        assert r.read(desc) is None  # manager.close() unlinked every segment
+    finally:
+        r.close()
+
+
+def test_slot_count_floor():
+    with pytest.raises(ValueError):
+        ShmRingWriter("sc_test_bad", slot_count=1)
+
+
+def test_writer_lifecycle_no_resource_tracker_error():
+    """A writer + reader on one segment, then teardown, must leave a clean
+    stderr. The reader and the writer share a resource_tracker here, so a
+    double-unregister (reader drops the name, then the writer's unlink drops it
+    again) would make the tracker raise KeyError. Runs in a fresh subprocess
+    loading shm.py standalone so the tracker's output is visible."""
+    import subprocess
+    import sys
+
+    from ros_sugar.robot import shm as shm_mod
+
+    script = (
+        "import importlib.util\n"
+        f"spec = importlib.util.spec_from_file_location('shm_standalone', {shm_mod.__file__!r})\n"
+        "m = importlib.util.module_from_spec(spec)\n"
+        "spec.loader.exec_module(m)\n"
+        "w = m.ShmRingWriter('sc_test_rt_lifecycle', slot_count=4)\n"
+        "r = m.ShmReaderCache()\n"
+        "d = w.write(bytes(4096))\n"
+        "assert r.read(d) is not None\n"
+        "r.close()\n"
+        "w.close()\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "resource_tracker" not in proc.stderr, proc.stderr
+    assert "Traceback" not in proc.stderr, proc.stderr


### PR DESCRIPTION
A robot plugin can now declare the driver nodes its feedback depends on and the launcher brings them up; large plugin feedbacks cross the multiprocess boundary through shared memory instead of CDR over the socket bus; and a component's process can be pinned or wrapped at launch with a prefix. Plus a fix to how ROS-topic feedbacks bind, mapping declarations, and control-limit names aligned with kompass-core.

## Plugin-declared driver processes

- `Plugin.required_processes()` returns `ProcessSpec`s; the launcher starts each one through `add_ros_node`, so a plugin's LiDAR or camera driver gets respawn (on by default), captured output and teardown ordered with the recipe, like any node a recipe adds by hand. Plugins declare, never spawn.
- `ProcessSpec.precondition` runs in the launcher right before the node is added; returning `False` skips it. This is what keeps a second copy of a port-binding driver from coming up "cleanly" next to the vendor's own instance and then never publishing.
- `Plugin.requested_feedbacks` / `requested_commands`: the keys this recipe's components actually consume, resolved from every `Topic(use_plugin=...)` before any host opens, so `required_processes()` and `on_attached()` can gate on real demand. Empty means nothing was asked for, not everything.
- A declaration that raises, or a precondition that fails, is logged and skipped; it never takes bringup down.
- `_setup_plugins` is idempotent, since `setup_launch_description` is public.
- Docs: "Bringing Up a Driver Node" in `custom_robot_plugin.md`.

## Shared-memory fast path for large feedbacks (multiprocess)

- `ros_sugar/robot/shm.py`: a per-channel POSIX shared-memory ring. `ShmRingWriter` on the HOST, one `ShmReaderCache` per consumer subscription, `PluginShmManager` owned by the launcher. Single writer, many readers, per-slot seqlock: a reader that loses the race gets a dropped frame, never torn bytes or a stall. The writer is the only party that unlinks, both sides opt out of the `resource_tracker`, and a frame that outgrows the slot moves the ring to a new epoch while the old segment stays mapped until close.
- `SupportedType.to_shm_payload` / `from_shm_payload` hooks, implemented for `Image`, `CompressedImage` and `PointCloud2`. Any other type, anything under `SHM_MIN_BYTES` (32 KiB), and any SHM failure takes the CDR path.
- Socket-bus payloads carry a one-byte kind tag (CDR or SHM descriptor). `Plugin.subscribe_feedback` decodes both and closes its reader on unsubscribe. A 1080p RGB frame puts under 1 KiB on the socket.
- The in-process bus now hands subscribers the live decoded message (`FeedbackBus.carries_objects`), so multithreaded launch pays no serialization at all. Consumers share the one instance with the Monitor and must treat it as read-only.
- `PointCloudData.buffer_layout()` hands raw-buffer consumers the buffer and the fields that describe it, nothing else.

## Message construction on the generated setter's fast path

- Sequence fields are assigned as an `array.array` of the field's typecode (`bytes_to_array`) in `Image`, `CompressedImage`, `OccupancyGrid` and `numpy_to_multiarray`, so rosidl takes the buffer as is instead of walking it element by element in Python.
- `Image.convert(ndarray)` builds a complete message: encoding inferred from dtype and channel count or passed explicitly, `step`, `is_bigendian`, and optional `stamp` / `frame_id` for callers building messages outside a publisher. It previously set only height, width and data.
- `CameraInfo.convert(CameraIntrinsics)` as the inverse of `read_camera_info`; `depth_image_metadata(encoding, depth_scale)`; the `image_pre_processing` byte-swap works on numpy 2.

## Robot plugin

- **ROS-topic feedbacks keep the recipe name.** Binding an input to a plugin's `RosTopicTransport` now changes only where it is subscribed (the plugin's topic, type and QoS). `callbacks`, `in_topics` and any name a component recorded stay the recipe's, which is the contract non-ROS transports already had. The explicit `ReplaceTopic` swap remains the one thing that changes an input's identity.
- `RobotPlugin.mounts`: a robot plugin places its own built-in sensors and the launcher publishes them as static TF, so no URDF is needed to resolve where they sit.
- `RobotPlugin.MAPPING`: `VendorMapping` (the vendor's SLAM tool as argv lists, its store, apply/export/import/remove) or `NativeMapping` (EMOS maps from the plugin's cloud and IMU feedbacks, named by feedback key). Surfaced by `describe()` and `python -m ros_sugar.robot inspect`; both answer `active_grid_path()` the same way.
- Plugin adaptation runs before `init_variables()`; a component that cached callback references there was left holding orphans.
- `from_spec` applies `frame_id` only to sensor plugins.

## Launcher and component

- **Fixes #63**: `BaseComponent.launch_prefix` is passed as `prefix` to the multiprocess launch action (`taskset`, `nice`, `chrt`, `perf record`, ...). Setting it on a threaded component warns, since there is no process of its own to apply it to.
- Shutdown no longer hangs under an internal-event flood: `ComponentLaunchAction` drops events once the launch context is shutting down, and its executor loop exits on the shutdown flag instead of waiting for an `OnShutdown` handler stuck behind the queue.
- `BaseComponent.log_once(key, message, level)` for lasting conditions; rclpy's `once=True` mutes per call site.
- A failure with no matching fallback policy is warned about once and broadcast, instead of adopting a stale fallback status. `Status.set_healthy()` clears the previous failure sources.
- Odometry transforms keep `twist` and `header`; `_replace_input_topic` keys the new callback by the normalized topic name.

## Breaking

- `LinearCtrlLimits.min_absolute_val` is now `min_vel` (default 0.05). `AngularCtrlLimits.max_vel` is `max_omega`, `max_steer` is `max_ang`, `min_absolute_val` is `min_omega`. The names match kompass-core's `LinearVelocityControlParams` / `AngularVelocityControlParams`, and both minimums must be greater than zero.
- ROS-topic plugin feedbacks no longer re-key `component.callbacks` / `in_topics` to the plugin's topic name.
- Feedback bus consumers: the in-process bus delivers message objects and the socket bus delivers tagged payloads. Go through `Plugin.subscribe_feedback` rather than deserializing bus bytes directly.
